### PR TITLE
Fix null dynamic component properties

### DIFF
--- a/client/scripts/models/mithril.ts
+++ b/client/scripts/models/mithril.ts
@@ -58,9 +58,7 @@ export const makeDynamicComponent = <
         // swap out each dynamic value with new value from subscription
         for (let i = 0; i < properties.length; ++i) {
           //console.log(`got update to ${properties[i]}: old = ${vnode.state.dynamic[name]}, new = ${results[i]}`);
-          if (results[i]) {
-            vnode.state.dynamic[properties[i]] = results[i];
-          }
+          vnode.state.dynamic[properties[i]] = results[i];
         }
         // in theory, we could diff the old/new and only redraw if something changed, but
         // redraws are cheap enough that it's not a big deal


### PR DESCRIPTION
Dynamic component properties wouldn't get cleared if the Observable it was listening to returned null; this fixes that edge case.
