### PR TITLE
Invite Links show commonwealth.im instead of localhost (bug fix)

### DIFF
--- a/client/scripts/views/pages/admin.ts
+++ b/client/scripts/views/pages/admin.ts
@@ -614,7 +614,7 @@ export const CreateInviteLink: m.Component<{onChangeHandler?: Function}, {link}>
               jwt: app.login.jwt,
             }).then((response) => {
               const linkInfo = response.result;
-              const url = (!app.isProduction) ? 'commonwealth.im' : 'localhost:8080';
+              const url = (app.isProduction) ? 'commonwealth.im' : 'localhost:8080';
               if (vnode.attrs.onChangeHandler) vnode.attrs.onChangeHandler(linkInfo);
               vnode.state.link = `${url}${app.serverUrl()}/acceptInviteLink?id=${linkInfo.id}`;
               m.redraw();
@@ -636,7 +636,7 @@ const InviteLinkRow: m.Component<{data}, {link}> = {
   },
   view: (vnode) => {
     const { id, active, multi_use, used, time_limit, created_at } = vnode.state.link;
-    const server = (!app.isProduction) ? 'commonwealth.im' : 'localhost:8080';
+    const server = (app.isProduction) ? 'commonwealth.im' : 'localhost:8080';
     const url = `${server}${app.serverUrl()}/acceptInviteLink?id=${id}`;
 
     return m('tr.InviteLinkRow', [


### PR DESCRIPTION
## Description
Fixes a typo in the formation of Generic Invite Links for Communities. Production was still generating localhost links. 

## Motivation and Context
Bug! We want to use this feature.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have linted the code locally prior to submission.
