### PR TITLE
Remove app imports overwritten by merge conflict.

### DIFF
--- a/client/scripts/controllers/chain/cosmos/main.ts
+++ b/client/scripts/controllers/chain/cosmos/main.ts
@@ -1,5 +1,3 @@
-import app from 'state';
-
 import { CosmosToken } from 'adapters/chain/cosmos/types';
 import { IChainAdapter, ChainBase, ChainClass } from 'models';
 import { CosmosAccount, CosmosAccounts } from './account';
@@ -25,9 +23,9 @@ class Cosmos extends IChainAdapter<CosmosToken, CosmosAccount> {
     this.chain = new CosmosChain(this.app);
     this.accounts = new CosmosAccounts(this.app);
     this.governance = new CosmosGovernance(this.app);
-    await app.threads.refreshAll(this.id, null, true);
-    await app.comments.refreshAll(this.id, null, true);
-    await app.reactions.refreshAll(this.id, null, true);
+    await this.app.threads.refreshAll(this.id, null, true);
+    await this.app.comments.refreshAll(this.id, null, true);
+    await this.app.reactions.refreshAll(this.id, null, true);
     this._serverLoaded = true;
     if (onServerLoaded) await onServerLoaded();
 
@@ -40,9 +38,9 @@ class Cosmos extends IChainAdapter<CosmosToken, CosmosAccount> {
   public deinit = async (): Promise<void> => {
     this._loaded = false;
     this._serverLoaded = false;
-    app.threads.deinit();
-    app.comments.deinit();
-    app.reactions.deinit();
+    this.app.threads.deinit();
+    this.app.comments.deinit();
+    this.app.reactions.deinit();
 
     await this.governance.deinit();
     await this.accounts.deinit();

--- a/client/scripts/controllers/chain/edgeware/main.ts
+++ b/client/scripts/controllers/chain/edgeware/main.ts
@@ -1,5 +1,3 @@
-import app from 'state';
-
 import EdgewareChain from 'controllers/chain/edgeware/shared';
 import SubstrateAccounts, { SubstrateAccount } from 'controllers/chain/substrate/account';
 import SubstrateDemocracy from 'controllers/chain/substrate/democracy';

--- a/client/scripts/controllers/chain/ethereum/main.ts
+++ b/client/scripts/controllers/chain/ethereum/main.ts
@@ -1,5 +1,3 @@
-import app from 'state';
-
 import { default as EthereumChain } from 'controllers/chain/ethereum/chain';
 import { default as EthereumAccounts, EthereumAccount } from 'controllers/chain/ethereum/account';
 import { EthereumCoin } from 'shared/adapters/chain/ethereum/types';
@@ -28,9 +26,9 @@ class Ethereum extends IChainAdapter<EthereumCoin, EthereumAccount> {
     console.log(`Starting ${this.meta.chain.id} on node: ${this.meta.url}`);
     this.chain = new EthereumChain(this.app);
     this.accounts = new EthereumAccounts(this.app);
-    await app.threads.refreshAll(this.id, null, true);
-    await app.comments.refreshAll(this.id, null, true);
-    await app.reactions.refreshAll(this.id, null, true);
+    await this.app.threads.refreshAll(this.id, null, true);
+    await this.app.comments.refreshAll(this.id, null, true);
+    await this.app.reactions.refreshAll(this.id, null, true);
 
     this._serverLoaded = true;
     if (onServerLoaded) await onServerLoaded();
@@ -41,7 +39,7 @@ class Ethereum extends IChainAdapter<EthereumCoin, EthereumAccount> {
     await this.chain.initEventLoop();
 
     await this.webWallet.web3.givenProvider.on('accountsChanged', function (accounts) {
-      const updatedAddress = app.login.activeAddresses.find((addr) => addr.address === accounts[0])
+      const updatedAddress = this.app.login.activeAddresses.find((addr) => addr.address === accounts[0])
       selectLogin(updatedAddress);
     });
 
@@ -51,9 +49,9 @@ class Ethereum extends IChainAdapter<EthereumCoin, EthereumAccount> {
   public deinit = async () => {
     this._loaded = false;
     this._serverLoaded = false;
-    app.threads.deinit();
-    app.comments.deinit();
-    app.reactions.deinit();
+    this.app.threads.deinit();
+    this.app.comments.deinit();
+    this.app.reactions.deinit();
     this.accounts.deinit();
     this.chain.deinitMetadata();
     this.chain.deinitEventLoop();

--- a/client/scripts/controllers/chain/ethereum/moloch/adapter.ts
+++ b/client/scripts/controllers/chain/ethereum/moloch/adapter.ts
@@ -1,5 +1,3 @@
-import app from 'state';
-
 import { MolochShares } from 'adapters/chain/ethereum/types';
 
 import EthWebWalletController from 'controllers/app/eth_web_wallet';
@@ -29,7 +27,7 @@ export default class Moloch extends IChainAdapter<MolochShares, EthereumAccount>
   get serverLoaded() { return this._serverLoaded; }
 
   public init = async (onServerLoaded?) => {
-    const useChainProposalData = this.meta.chain.id === 'moloch-local' || !app.isProduction();
+    const useChainProposalData = this.meta.chain.id === 'moloch-local' || !this.app.isProduction();
     // FIXME: This is breaking for me on moloch default (not local)
     // if (!this.meta.chain.chainObjectId && !useChainProposalData) {
     //   throw new Error('no chain object id found');

--- a/client/scripts/controllers/chain/near/main.ts
+++ b/client/scripts/controllers/chain/near/main.ts
@@ -1,5 +1,3 @@
-import app from 'state';
-
 import { IChainAdapter, ChainBase, ChainClass } from 'models';
 
 import { NearToken } from 'adapters/chain/near/types';

--- a/client/scripts/controllers/chain/substrate/democracy_proposals.ts
+++ b/client/scripts/controllers/chain/substrate/democracy_proposals.ts
@@ -1,4 +1,3 @@
-import app from 'state';
 import { Unsubscribable, Observable } from 'rxjs';
 import { map, first } from 'rxjs/operators';
 import { Codec } from '@polkadot/types/types';
@@ -42,7 +41,7 @@ class SubstrateDemocracyProposals extends ProposalModule<
   get minimumDeposit() { return this._minimumDeposit; }
 
   get nextLaunchBlock(): number {
-    return (Math.floor(app.chain.block.height / this.launchPeriod) + 1) * this.launchPeriod;
+    return (Math.floor(this.app.chain.block.height / this.launchPeriod) + 1) * this.launchPeriod;
   }
 
   private _lastTabledWasExternal: boolean = null;

--- a/client/scripts/controllers/chain/substrate/main.ts
+++ b/client/scripts/controllers/chain/substrate/main.ts
@@ -1,5 +1,3 @@
-import app from 'state';
-
 import SubstrateChain from 'controllers/chain/substrate/shared';
 import SubstrateAccounts, { SubstrateAccount } from 'controllers/chain/substrate/account';
 import SubstrateDemocracy from 'controllers/chain/substrate/democracy';
@@ -46,9 +44,9 @@ class Substrate extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
     this.democracy = new SubstrateDemocracy(this.app);
     this.treasury = new SubstrateTreasury(this.app);
     this.identities = new SubstrateIdentities(this.app);
-    await app.threads.refreshAll(this.id, null, true);
-    await app.comments.refreshAll(this.id, null, true);
-    await app.reactions.refreshAll(this.id, null, true);
+    await this.app.threads.refreshAll(this.id, null, true);
+    await this.app.comments.refreshAll(this.id, null, true);
+    await this.app.reactions.refreshAll(this.id, null, true);
     this._serverLoaded = true;
     if (onServerLoaded) await onServerLoaded();
 
@@ -72,9 +70,9 @@ class Substrate extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
   public deinit = async (): Promise<void> => {
     this._loaded = false;
     this._serverLoaded = false;
-    app.threads.deinit();
-    app.comments.deinit();
-    app.reactions.deinit();
+    this.app.threads.deinit();
+    this.app.comments.deinit();
+    this.app.reactions.deinit();
     this.chain.deinitEventLoop();
     await Promise.all([
       this.phragmenElections.deinit(),

--- a/client/scripts/controllers/chain/substrate/treasury.ts
+++ b/client/scripts/controllers/chain/substrate/treasury.ts
@@ -3,7 +3,6 @@ import { first } from 'rxjs/operators';
 import { ApiRx } from '@polkadot/api';
 import { BalanceOf, Permill, BlockNumber } from '@polkadot/types/interfaces';
 
-import app from 'state';
 import { formatCoin } from 'adapters/currency';
 import { formatAddressShort } from 'helpers';
 import {
@@ -49,7 +48,7 @@ class SubstrateTreasury extends ProposalModule<
   get spendPeriod() { return this._spendPeriod; }
 
   get nextSpendBlock(): number {
-    return (Math.floor(app.chain.block.height / this.spendPeriod) + 1) * this.spendPeriod;
+    return (Math.floor(this.app.chain.block.height / this.spendPeriod) + 1) * this.spendPeriod;
   }
 
   public computeBond(amount: SubstrateCoin): SubstrateCoin {


### PR DESCRIPTION
## Description
PR #2 was intended to remove imports of the global `app` object from the chain-related controllers, but some of the changes were lost in merge resolution. This PR reintroduces those fixes.

## How Has This Been Tested?
It builds and runs.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
