### PR TITLE
Email Upgrade to Mentions

### DIFF
--- a/client/scripts/views/pages/subscriptions.ts
+++ b/client/scripts/views/pages/subscriptions.ts
@@ -36,6 +36,14 @@ const NotificationButtons: m.Component = {
   }
 };
 
+const NotificationTab: m.Component = {
+  view: (vnode) => {
+    return m('.NotificationTab', [
+      m(NotificationButtons),
+    ]);
+  }
+};
+
 interface ICoCSubscriptionsButtonAttrs {
   community?: CommunityInfo;
   chain?: ChainInfo;
@@ -89,6 +97,7 @@ const SubscriptionRow: m.Component<ISubscriptionRowAttrs, ISubscriptionRowState>
     if (activeSubscription) {
       vnode.state.subscription = activeSubscription;
     }
+    const mentions = (vnode.state.subscription.category === 'new-mention');
     return m('.SubscriptionRow', [
       m('h3', `${vnode.state.subscription.objectId}`),
       m('h4', `Subscription Type: ${vnode.state.subscription.category}`),
@@ -106,26 +115,27 @@ const SubscriptionRow: m.Component<ISubscriptionRowAttrs, ISubscriptionRowState>
             m.redraw();
           }
         }, activeSubscription.isActive ? 'Pause' : 'Unpause'),
-      m('button.activeSubscriptionButton', {
-        class: activeSubscription ? 'formular-button-primary' : '',
-        href: '#',
-        onclick: (e) => {
-          e.preventDefault();
-          if (activeSubscription) {
-            subscriptions.deleteSubscription(activeSubscription).then(() => {
-              m.redraw();
-            });
-          } else {
-            subscriptions.subscribe(vnode.state.subscription.category, vnode.state.subscription.objectId).then(() => {
-              m.redraw();
-            });
+      !mentions &&
+        m('button.activeSubscriptionButton', {
+          class: activeSubscription ? 'formular-button-primary' : '',
+          href: '#',
+          onclick: (e) => {
+            e.preventDefault();
+            if (activeSubscription) {
+              subscriptions.deleteSubscription(activeSubscription).then(() => {
+                m.redraw();
+              });
+            } else {
+              subscriptions.subscribe(vnode.state.subscription.category, vnode.state.subscription.objectId).then(() => {
+                m.redraw();
+              });
+            }
           }
-        }
-      }, [
-        activeSubscription
-          ? [ m('span.icon-bell'), ' Notifications on' ]
-          : [ m('span.icon-bell-off'), ' Notifications off' ]
-      ]),
+        }, [
+          activeSubscription
+            ? [ m('span.icon-bell'), ' Notifications on' ]
+            : [ m('span.icon-bell-off'), ' Notifications off' ]
+        ]),
     ]);
   }
 };
@@ -326,7 +336,7 @@ const SubscriptionsPage: m.Component = {
           content: m(CommunitySubscriptions),
         }, {
           name: 'Notifications',
-          content: m(NotificationButtons),
+          content: m(NotificationTab),
         },
         ]),
       ]),

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -212,7 +212,7 @@ const createComment = async (models, req: UserRequest, res: Response, next: Next
             category_id: NotificationCategories.NewMention,
           },
         });
-        if (subscription.is_active) {
+        if (subscription.is_active && mentionedAddress.User.email) {
           const msg = {
             to: mentionedAddress.User.email,
             from: 'Commonwealth <no-reply@commonwealth.im>',

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -180,25 +180,30 @@ const createComment = async (models, req: UserRequest, res: Response, next: Next
           if (destinationCommunity === undefined) shouldNotifyMentionedUser = false;
         }
       }
-      if (shouldNotifyMentionedUser) await models.Subscription.emitNotifications(
-        models,
-        NotificationCategories.NewMention,
-        `user-${mentionedAddress.User.id}`,
-        {
-          created_at: new Date(),
-          mention_context: 'comment',
-          thread_title: commentedObject?.title,
-          thread_id: commentedObject?.id,
-          root_id,
-          comment_text: finalComment.text,
-          comment_id: finalComment.id,
-          chain_id: finalComment.chain,
-          community_id: finalComment.community,
-          author_address: finalComment.Address.address,
-          author_chain: finalComment.Address.chain,
-        },
-        req.wss
-      );
+      if (shouldNotifyMentionedUser) {
+        const subscription = await models.Subscription.emitNotifications(
+          models,
+          NotificationCategories.NewMention,
+          `user-${mentionedAddress.User.id}`,
+          {
+            created_at: new Date(),
+            mention_context: 'comment',
+            thread_title: commentedObject?.title,
+            thread_id: commentedObject?.id,
+            root_id,
+            comment_text: finalComment.text,
+            comment_id: finalComment.id,
+            chain_id: finalComment.chain,
+            community_id: finalComment.community,
+            author_address: finalComment.Address.address,
+            author_chain: finalComment.Address.chain,
+          },
+          req.wss
+        );
+        if (subscription.isActive) {
+          // Send Email
+        }
+      }
     }));
   }
 

--- a/server/routes/createThread.ts
+++ b/server/routes/createThread.ts
@@ -240,7 +240,7 @@ const createThread = async (models, req: UserRequest, res: Response, next: NextF
           category_id: NotificationCategories.NewMention,
         },
       });
-      if (subscription.is_active) {
+      if (subscription.is_active && mentionedAddress.User.email) {
         const msg = {
           to: mentionedAddress.User.email,
           from: 'Commonwealth <no-reply@commonwealth.im>',

--- a/server/routes/createThread.ts
+++ b/server/routes/createThread.ts
@@ -211,22 +211,27 @@ const createThread = async (models, req: UserRequest, res: Response, next: NextF
         if (destinationCommunity === undefined) shouldNotifyMentionedUser = false;
       }
     }
-    if (shouldNotifyMentionedUser) await models.Subscription.emitNotifications(
-      models,
-      NotificationCategories.NewMention,
-      `user-${mentionedAddress.User.id}`,
-      {
-        created_at: new Date(),
-        mention_context: 'thread',
-        thread_title: finalThread.title,
-        thread_id: finalThread.id,
-        chain_id: finalThread.chain,
-        community_id: finalThread.community,
-        author_address: finalThread.Address.address,
-        author_chain: finalThread.Address.chain,
-      },
-      req.wss
-    );
+    if (shouldNotifyMentionedUser) {
+      const subscription = await models.Subscription.emitNotifications(
+        models,
+        NotificationCategories.NewMention,
+        `user-${mentionedAddress.User.id}`,
+        {
+          created_at: new Date(),
+          mention_context: 'thread',
+          thread_title: finalThread.title,
+          thread_id: finalThread.id,
+          chain_id: finalThread.chain,
+          community_id: finalThread.community,
+          author_address: finalThread.Address.address,
+          author_chain: finalThread.Address.chain,
+        },
+        req.wss
+      );
+      if (subscription.isActive) {
+        // Send Email
+      }
+    }
   }));
 
   return res.json({ status: 'Success', result: finalThread.toJSON() });


### PR DESCRIPTION
### This can be considered a WIP PR on this branch until further specifications are confirmed.

## Description
New features related to a Notification from a "Mention":
- Email sent when notification emits, if Notification Subscription for Mentions is currently active. 
- Mentions Subscription modified in Subscriptions Page Panel

## Motivation and Context
The motivation behind this is to encourage users to engage and be engaged by the community-generated content. 

## Tested
- [x] Sent email for 'new-mention' notification in threads (`/createThread` route)
- [x] Sent email for 'new-mention' notification in comments (`/createComment` route)
- [x] In the Subscriptions Panel, under Active Subscriptions, the Pause Notification Toggle button stops emails + notifications from being sent.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] My change should be included in the release notes.
- [ ] I have updated the documentation accordingly.
- [x] I have linted the code locally prior to submission.
