### PR TITLE
Comment/Thread edit bug fixed when no change occurs

### DIFF
--- a/client/scripts/views/pages/view_proposal.ts
+++ b/client/scripts/views/pages/view_proposal.ts
@@ -132,6 +132,7 @@ interface IProposalBodyAttrs {
 interface IProposalBodyState {
   editing: boolean;
   quillEditorState: any;
+  currentText: any;
 }
 
 const ProposalHeader: m.Component<IProposalHeaderAttrs> = {
@@ -303,6 +304,7 @@ export const ProposalBody: m.Component<IProposalBodyAttrs, IProposalBodyState> =
               href: '#',
               onclick: async (e) => {
                 e.preventDefault();
+                vnode.state.currentText = proposal['body'] || proposal['description'];
                 if (getSetGlobalReplyStatus(GlobalStatus.Get)) {
                   if (activeQuillEditorHasText()) {
                     const confirmed = await confirmationModalWithText('Unsubmitted replies will be lost. Continue?')();
@@ -335,8 +337,13 @@ export const ProposalBody: m.Component<IProposalBodyAttrs, IProposalBodyState> =
               href: '#',
               onclick: async (e) => {
                 e.preventDefault();
-                // TODO: Only show confirmation modal if edits have been made
-                const confirmed = await confirmationModalWithText('Cancel editing? Changes will not be saved.')();
+                let confirmed = true;
+                const threadText = vnode.state.quillEditorState.markdownMode
+                  ? vnode.state.quillEditorState.editor.getText()
+                  : JSON.stringify(vnode.state.quillEditorState.editor.getContents());
+                if (threadText !== vnode.state.currentText) {
+                  confirmed = await confirmationModalWithText('Cancel editing? Changes will not be saved.')();
+                }
                 if (!confirmed) return;
                 vnode.state.editing = false;
                 getSetGlobalEditingStatus(GlobalStatus.Set, false);
@@ -426,6 +433,7 @@ interface IProposalCommentState {
   editing: boolean;
   replying: boolean;
   quillEditorState: any;
+  currentText: any;
 }
 
 interface IProposalCommentAttrs {
@@ -509,6 +517,7 @@ const ProposalComment: m.Component<IProposalCommentAttrs, IProposalCommentState>
               onclick: async (e) => {
                 e.preventDefault();
                 vnode.state.editing = true;
+                vnode.state.currentText = comment.text;
                 if (getSetGlobalReplyStatus(GlobalStatus.Get)) {
                   if (activeQuillEditorHasText()) {
                     const confirmed = await confirmationModalWithText('Unsubmitted replies will be lost. Continue?')();
@@ -540,8 +549,13 @@ const ProposalComment: m.Component<IProposalCommentAttrs, IProposalCommentState>
               href: '#',
               onclick: async (e) => {
                 e.preventDefault();
-                // TODO: Only show confirmation modal if edits have been made
-                const confirmed = await confirmationModalWithText('Cancel editing? Changes will not be saved.')();
+                let confirmed = true;
+                const commentText = vnode.state.quillEditorState.markdownMode
+                  ? vnode.state.quillEditorState.editor.getText()
+                  : JSON.stringify(vnode.state.quillEditorState.editor.getContents());
+                if (commentText !== vnode.state.currentText) {
+                  confirmed = await confirmationModalWithText('Cancel editing? Changes will not be saved.')();
+                }
                 if (!confirmed) return;
                 vnode.state.editing = false;
                 getSetGlobalEditingStatus(GlobalStatus.Set, false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When you click edit to a comment or thread and do not change anything, cancelling does not prompt you with any modal.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It was a bug that needed a fixin. A user shouldn't need to go through extra steps when they haven't edited anything.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ensuring that in both rich text/markdown and thread/comment edits the intended effect occurs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have linted the code locally prior to submission.
