### PR TITLE
Switch CircleCI tests to API only.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,33 +31,7 @@ jobs:
           name: "set env var for no client"
           command: echo 'export NO_CLIENT="true"' >> $BASH_ENV
       - run:
-          name: initialize the db
-          command: yarn reset-server
-      - run:
-          name: add testing chain object queries to db
-          command: yarn add-test-queries
-      - run:
-          name: start mock provider server
-          command: yarn mock-graphql-provider
-          background: true
-      - run:
-          name: wait for mock provider server
-          command: dockerize -wait tcp://localhost:4000 -timeout 1m
-      - run:
-          name: install headless chrome
-          command: ./scripts/install_headless_chrome.sh
-      - run:
-          name: start main server
-          command: yarn start-ci
-          background: true
-      - run:
-          name: wait for main server
-          command: dockerize -wait tcp://localhost:8080 -timeout 3m
-      - run:
-          name: sleep to finish init
-          command: sleep 10
-      - run:
-          name: run tests
-          command: yarn test
+          name: run api tests
+          command: yarn test-api
       - store_artifacts:
           path: coverage


### PR DESCRIPTION
## Description
We use CircleCI as a continuous integration platform to run our tests. Currently, we only run the tests I wrote for "chain objects", which are fragile and bloated integration tests (it involves multiple background processes, sleeps, etc).

This PR replaces the set of CircleCI test cases with the API tests that @drewstone and others have been working on.

## Motivation and Context
We want to be able to use CircleCI as a CI platform again, as we were before the controller tests were deprecated.

## How Has This Been Tested?
This branch's run was successful (and note the coverage output in artifacts): https://app.circleci.com/pipelines/github/hicommonwealth/commonwealth-oss/27/workflows/447ec5a0-496d-4b82-9828-68746cd31f92/jobs/27
