### PR TITLE
Fix count and remove dispatch queue proposals from page.

### DIFF
--- a/client/scripts/views/components/header.ts
+++ b/client/scripts/views/components/header.ts
@@ -193,7 +193,7 @@ const Navigation: m.Component<IMenuAttrs> = {
       : app.activeCommunityId() ? app.community.meta.defaultChain.id : 'edgeware';
 
     const substrateGovernanceProposals = (app.chain && app.chain.base === ChainBase.Substrate) ?
-      ((app.chain as Substrate).democracy.store.getAll().filter((p) => !p.completed).length
+      ((app.chain as Substrate).democracy.store.getAll().filter((p) => !p.completed && !p.passed).length
        + (app.chain as Substrate).democracyProposals.store.getAll().filter((p) => !p.completed).length
        + (app.chain as Substrate).council.store.getAll().filter((p) => !p.completed).length
        + (app.chain as Substrate).treasury.store.getAll().filter((p) => !p.completed).length) : 0;

--- a/client/scripts/views/pages/proposals.ts
+++ b/client/scripts/views/pages/proposals.ts
@@ -34,7 +34,8 @@ const ProposalsPage: m.Component<{}> = {
     const visibleMolochProposals = onMoloch && (app.chain as Moloch).governance.store.getAll()
       .sort((p1, p2) => +p2.data.timestamp - +p1.data.timestamp);
 
-    const visibleDispatchQueue = onSubstrate && (app.chain as Substrate).democracy.store.getAll().filter((p) => !p.completed && p.passed);
+    // do not display the dispatch queue as full proposals for now
+    const visibleDispatchQueue = []; // onSubstrate && (app.chain as Substrate).democracy.store.getAll().filter((p) => !p.completed && p.passed);
     const visibleReferenda = onSubstrate && (app.chain as Substrate).democracy.store.getAll().filter((p) => !p.completed && !p.passed);
 
     const visibleDemocracyProposals = onSubstrate && (app.chain as Substrate).democracyProposals.store.getAll();


### PR DESCRIPTION
## Description
Currently, on Edgeware, we do not display proposals in the dispatch queue, although we do on Kusama. However, we count them both in the Header.

This patch removes dispatch queued proposals from the header count, and unifies the function of Kusama and Edgeware by simply not displaying proposals in the dispatch queue.

We may want to add a separate dispatch queue display, however, as the dispatch queue contents are useful for users to know.

## How Has This Been Tested?
Ran it, made a proposal, checked the count and page.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] My change should be included in the release notes.
- [ ] I have updated the documentation accordingly.
- [ ] I have linted the code locally prior to submission.
