### PR TITLE
Separate chainAdapterReady from chainModuleReady.

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -214,7 +214,7 @@ export async function selectNode(n?: NodeInfo): Promise<void> {
   console.log(`${n.chain.network.toUpperCase()} started.`);
 
   // Emit chain as updated
-  app.chainReady.next(true);
+  app.chainAdapterReady.next(true);
   handleInviteLinkRedirect();
 
   // Reset the available addresses only if switching chains

--- a/client/scripts/controllers/chain/community/main.ts
+++ b/client/scripts/controllers/chain/community/main.ts
@@ -15,6 +15,7 @@ class Community extends ICommunityAdapter<Coin, OffchainAccount> {
 
   public init = async () => {
     console.log(`Starting ${this.meta.name}`);
+    this.app.chainModuleReady.next(true);
     this.accounts = new OffchainAccounts(this.app);
     await this.app.threads.refreshAll(null, this.id, true);
     await this.app.comments.refreshAll(null, this.id, true);

--- a/client/scripts/controllers/chain/community/main.ts
+++ b/client/scripts/controllers/chain/community/main.ts
@@ -15,7 +15,6 @@ class Community extends ICommunityAdapter<Coin, OffchainAccount> {
 
   public init = async () => {
     console.log(`Starting ${this.meta.name}`);
-    this.app.chainModuleReady.next(true);
     this.accounts = new OffchainAccounts(this.app);
     await this.app.threads.refreshAll(null, this.id, true);
     await this.app.comments.refreshAll(null, this.id, true);

--- a/client/scripts/controllers/chain/cosmos/account.ts
+++ b/client/scripts/controllers/chain/cosmos/account.ts
@@ -226,7 +226,7 @@ export class CosmosAccount extends Account<CosmosToken> {
     super(app, app.chain.meta.chain, address);
     if (!ChainInfo) {
       // defer chain initialization
-      app.chainReady.pipe(first()).subscribe(() => {
+      app.chainModuleReady.pipe(first()).subscribe(() => {
         if (app.chain.chain instanceof CosmosChain) this._Chain = app.chain.chain;
         else console.error('Did not successfully initialize account with chain');
       });

--- a/client/scripts/controllers/chain/cosmos/main.ts
+++ b/client/scripts/controllers/chain/cosmos/main.ts
@@ -21,6 +21,7 @@ class Cosmos extends IChainAdapter<CosmosToken, CosmosAccount> {
   public init = async (onServerLoaded?) => {
     console.log(`Starting ${this.meta.chain.id} on node: ${this.meta.url}`);
     this.chain = new CosmosChain(this.app);
+    this.app.chainModuleReady.next(true);
     this.accounts = new CosmosAccounts(this.app);
     this.governance = new CosmosGovernance(this.app);
     await this.app.threads.refreshAll(this.id, null, true);

--- a/client/scripts/controllers/chain/cosmos/main.ts
+++ b/client/scripts/controllers/chain/cosmos/main.ts
@@ -15,22 +15,15 @@ class Cosmos extends IChainAdapter<CosmosToken, CosmosAccount> {
   private _loaded: boolean = false;
   public get loaded() { return this._loaded; }
 
-  private _serverLoaded: boolean = false;
-  public get serverLoaded() { return this._serverLoaded; }
-
-  public init = async (onServerLoaded?) => {
+  public async init(onServerLoaded?) {
     console.log(`Starting ${this.meta.chain.id} on node: ${this.meta.url}`);
     this.chain = new CosmosChain(this.app);
-    this.app.chainModuleReady.next(true);
     this.accounts = new CosmosAccounts(this.app);
     this.governance = new CosmosGovernance(this.app);
-    await this.app.threads.refreshAll(this.id, null, true);
-    await this.app.comments.refreshAll(this.id, null, true);
-    await this.app.reactions.refreshAll(this.id, null, true);
-    this._serverLoaded = true;
-    if (onServerLoaded) await onServerLoaded();
 
-    await this.chain.init(this.meta);
+    await super.init(async () => {
+      await this.chain.init(this.meta);
+    }, onServerLoaded);
     await this.accounts.init(this.chain);
     await this.governance.init(this.chain, this.accounts);
     this._loaded = true;

--- a/client/scripts/controllers/chain/edgeware/main.ts
+++ b/client/scripts/controllers/chain/edgeware/main.ts
@@ -37,10 +37,7 @@ class Edgeware extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
   private _loaded: boolean = false;
   get loaded() { return this._loaded; }
 
-  private _serverLoaded: boolean = false;
-  get serverLoaded() { return this._serverLoaded; }
-
-  public init = async (onServerLoaded?) => {
+  public async init(onServerLoaded?) {
     console.log(`Starting ${this.meta.chain.id} on node: ${this.meta.url}`);
     this.chain = new EdgewareChain(this.app); // edgeware chain this.appid
     this.accounts = new SubstrateAccounts(this.app);
@@ -51,33 +48,29 @@ class Edgeware extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
     this.democracy = new SubstrateDemocracy(this.app);
     this.treasury = new SubstrateTreasury(this.app);
     this.signaling = new EdgewareSignaling(this.app);
-    await this.app.threads.refreshAll(this.id, null, true);
-    await this.app.comments.refreshAll(this.id, null, true);
-    await this.app.reactions.refreshAll(this.id, null, true);
-    // await this.server.proposals.init();
-    this._serverLoaded = true;
-    if (onServerLoaded) await onServerLoaded();
 
-    const types = Object.values(edgewareDefinitions).reduce((res, { types }): object => ({ ...res, ...types }), {});
+    await super.init(async () => {
+      const edgTypes = Object.values(edgewareDefinitions)
+        .reduce((res, { types }): object => ({ ...res, ...types }), {});
 
-    await this.chain.resetApi(this.meta, {
-      types: {
-        ...types,
-        // aliases that don't do well as part of interfaces
-        'voting::VoteType': 'VoteType',
-        'voting::TallyType': 'TallyType',
-        // chain-specific overrides
-        Address: 'GenericAddress',
-        Keys: 'SessionKeys4',
-        StakingLedger: 'StakingLedgerTo223',
-        Votes: 'VotesTo230',
-        ReferendumInfo: 'ReferendumInfoTo239',
-      },
-      // override duplicate type name
-      typesAlias: { voting: { Tally: 'VotingTally' } },
-    });
-    await this.chain.initMetadata();
-    this.app.chainModuleReady.next(true);
+      await this.chain.resetApi(this.meta, {
+        types: {
+          ...edgTypes,
+          // aliases that don't do well as part of interfaces
+          'voting::VoteType': 'VoteType',
+          'voting::TallyType': 'TallyType',
+          // chain-specific overrides
+          Address: 'GenericAddress',
+          Keys: 'SessionKeys4',
+          StakingLedger: 'StakingLedgerTo223',
+          Votes: 'VotesTo230',
+          ReferendumInfo: 'ReferendumInfoTo239',
+        },
+        // override duplicate type name
+        typesAlias: { voting: { Tally: 'VotingTally' } },
+      });
+      await this.chain.initMetadata();
+    }, onServerLoaded);
     await this.accounts.init(this.chain);
     await Promise.all([
       this.phragmenElections.init(this.chain, this.accounts, 'elections'),

--- a/client/scripts/controllers/chain/edgeware/main.ts
+++ b/client/scripts/controllers/chain/edgeware/main.ts
@@ -77,6 +77,7 @@ class Edgeware extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
       typesAlias: { voting: { Tally: 'VotingTally' } },
     });
     await this.chain.initMetadata();
+    this.app.chainModuleReady.next(true);
     await this.accounts.init(this.chain);
     await Promise.all([
       this.phragmenElections.init(this.chain, this.accounts, 'elections'),

--- a/client/scripts/controllers/chain/ethereum/main.ts
+++ b/client/scripts/controllers/chain/ethereum/main.ts
@@ -25,6 +25,7 @@ class Ethereum extends IChainAdapter<EthereumCoin, EthereumAccount> {
   public init = async (onServerLoaded?) => {
     console.log(`Starting ${this.meta.chain.id} on node: ${this.meta.url}`);
     this.chain = new EthereumChain(this.app);
+    this.app.chainModuleReady.next(true);
     this.accounts = new EthereumAccounts(this.app);
     await this.app.threads.refreshAll(this.id, null, true);
     await this.app.comments.refreshAll(this.id, null, true);

--- a/client/scripts/controllers/chain/ethereum/main.ts
+++ b/client/scripts/controllers/chain/ethereum/main.ts
@@ -19,23 +19,15 @@ class Ethereum extends IChainAdapter<EthereumCoin, EthereumAccount> {
   private _loaded: boolean = false;
   get loaded() { return this._loaded; }
 
-  private _serverLoaded: boolean = false;
-  get serverLoaded() { return this._serverLoaded; }
-
-  public init = async (onServerLoaded?) => {
+  public async init(onServerLoaded?) {
     console.log(`Starting ${this.meta.chain.id} on node: ${this.meta.url}`);
     this.chain = new EthereumChain(this.app);
-    this.app.chainModuleReady.next(true);
     this.accounts = new EthereumAccounts(this.app);
-    await this.app.threads.refreshAll(this.id, null, true);
-    await this.app.comments.refreshAll(this.id, null, true);
-    await this.app.reactions.refreshAll(this.id, null, true);
 
-    this._serverLoaded = true;
-    if (onServerLoaded) await onServerLoaded();
-
-    await this.chain.resetApi(this.meta);
-    await this.chain.initMetadata();
+    await super.init(async () => {
+      await this.chain.resetApi(this.meta);
+      await this.chain.initMetadata();
+    }, onServerLoaded);
     await this.accounts.init(this.chain);
     await this.chain.initEventLoop();
 

--- a/client/scripts/controllers/chain/ethereum/moloch/adapter.ts
+++ b/client/scripts/controllers/chain/ethereum/moloch/adapter.ts
@@ -21,12 +21,9 @@ export default class Moloch extends IChainAdapter<MolochShares, EthereumAccount>
   public readonly webWallet: EthWebWalletController = new EthWebWalletController();
 
   private _loaded: boolean = false;
-  private _serverLoaded: boolean = false;
-
   get loaded() { return this._loaded; }
-  get serverLoaded() { return this._serverLoaded; }
 
-  public init = async (onServerLoaded?) => {
+  public async init(onServerLoaded?) {
     const useChainProposalData = this.meta.chain.id === 'moloch-local' || !this.app.isProduction();
     // FIXME: This is breaking for me on moloch default (not local)
     // if (!this.meta.chain.chainObjectId && !useChainProposalData) {
@@ -37,15 +34,11 @@ export default class Moloch extends IChainAdapter<MolochShares, EthereumAccount>
     this.ethAccounts = new EthereumAccounts(this.app);
     this.accounts = new MolochMembers(this.app);
     this.governance = new MolochGovernance(this.app);
-    await this.app.threads.refreshAll(this.id, null, true);
-    await this.app.comments.refreshAll(this.id, null, true);
-    await this.app.reactions.refreshAll(this.id, null, true);
 
-    this._serverLoaded = true;
-    if (onServerLoaded) await onServerLoaded();
-
-    await this.chain.resetApi(this.meta);
-    await this.chain.initMetadata();
+    await super.init(async () => {
+      await this.chain.resetApi(this.meta);
+      await this.chain.initMetadata();
+    }, onServerLoaded);
     await this.ethAccounts.init(this.chain);
     await this.chain.initEventLoop();
     await this.webWallet.enable();

--- a/client/scripts/controllers/chain/near/main.ts
+++ b/client/scripts/controllers/chain/near/main.ts
@@ -14,21 +14,14 @@ export default class Near extends IChainAdapter<NearToken, any> {
   private _loaded: boolean = false;
   get loaded() { return this._loaded; }
 
-  private _serverLoaded: boolean = false;
-  get serverLoaded() { return this._serverLoaded; }
-
-  public init = async (onServerLoaded?) => {
+  public async init(onServerLoaded?) {
     console.log(`Starting ${this.meta.chain.id} on node: ${this.meta.url}`);
     this.chain = new NearChain(this.app);
-    this.app.chainModuleReady.next(true);
     this.accounts = new NearAccounts(this.app);
-    await this.app.threads.refreshAll(this.id, null, true);
-    await this.app.comments.refreshAll(this.id, null, true);
-    await this.app.reactions.refreshAll(this.id, null, true);
-    this._serverLoaded = true;
-    if (onServerLoaded) await onServerLoaded();
 
-    await this.chain.init(this.meta);
+    await super.init(async () => {
+      await this.chain.init(this.meta);
+    }, onServerLoaded);
     await this.accounts.init(this.chain);
 
     this._loaded = true;

--- a/client/scripts/controllers/chain/near/main.ts
+++ b/client/scripts/controllers/chain/near/main.ts
@@ -20,6 +20,7 @@ export default class Near extends IChainAdapter<NearToken, any> {
   public init = async (onServerLoaded?) => {
     console.log(`Starting ${this.meta.chain.id} on node: ${this.meta.url}`);
     this.chain = new NearChain(this.app);
+    this.app.chainModuleReady.next(true);
     this.accounts = new NearAccounts(this.app);
     await this.app.threads.refreshAll(this.id, null, true);
     await this.app.comments.refreshAll(this.id, null, true);

--- a/client/scripts/controllers/chain/substrate/account.ts
+++ b/client/scripts/controllers/chain/substrate/account.ts
@@ -326,7 +326,7 @@ export class SubstrateAccount extends Account<SubstrateCoin> {
     if (!ChainInfo) {
       // defer chain initialization
       super(app, app.chain.meta.chain, address, null);
-      app.chainReady.pipe(first()).subscribe(() => {
+      app.chainModuleReady.pipe(first()).subscribe(() => {
         if (app.chain.chain instanceof SubstrateChain) {
           this._Chain = app.chain.chain;
           this.setEncoding(this._Chain.ss58Format);

--- a/client/scripts/controllers/chain/substrate/main.ts
+++ b/client/scripts/controllers/chain/substrate/main.ts
@@ -52,6 +52,7 @@ class Substrate extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
 
     await this.chain.resetApi(this.meta);
     await this.chain.initMetadata();
+    this.app.chainModuleReady.next(true);
     await this.accounts.init(this.chain);
     await Promise.all([
       this.phragmenElections.init(this.chain, this.accounts),

--- a/client/scripts/controllers/chain/substrate/main.ts
+++ b/client/scripts/controllers/chain/substrate/main.ts
@@ -27,13 +27,10 @@ class Substrate extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
   private _loaded: boolean = false;
   public get loaded() { return this._loaded; }
 
-  private _serverLoaded: boolean = false;
-  public get serverLoaded() { return this._serverLoaded; }
-
   public readonly base = ChainBase.Substrate;
   public readonly class = ChainClass.Kusama;
 
-  public init = async (onServerLoaded?) => {
+  public async init(onServerLoaded?) {
     console.log(`Starting ${this.meta.chain.id} on node: ${this.meta.url}`);
     this.chain = new SubstrateChain(this.app); // kusama chain id
     this.accounts = new SubstrateAccounts(this.app);
@@ -44,15 +41,11 @@ class Substrate extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
     this.democracy = new SubstrateDemocracy(this.app);
     this.treasury = new SubstrateTreasury(this.app);
     this.identities = new SubstrateIdentities(this.app);
-    await this.app.threads.refreshAll(this.id, null, true);
-    await this.app.comments.refreshAll(this.id, null, true);
-    await this.app.reactions.refreshAll(this.id, null, true);
-    this._serverLoaded = true;
-    if (onServerLoaded) await onServerLoaded();
 
-    await this.chain.resetApi(this.meta);
-    await this.chain.initMetadata();
-    this.app.chainModuleReady.next(true);
+    await super.init(async () => {
+      await this.chain.resetApi(this.meta);
+      await this.chain.initMetadata();
+    }, onServerLoaded);
     await this.accounts.init(this.chain);
     await Promise.all([
       this.phragmenElections.init(this.chain, this.accounts),

--- a/client/scripts/models/mithril.ts
+++ b/client/scripts/models/mithril.ts
@@ -33,7 +33,7 @@ export const makeDynamicComponent = <
 
   const subscribeObservables = (vnode: m.VnodeDOM<Attrs, State>) => {
     // wait for the chain to become available before initializing dynamic components
-    app.chainReady.pipe(first()).subscribe(() => {
+    app.chainAdapterReady.pipe(first()).subscribe(() => {
       const observables = component.getObservables(vnode.attrs);
 
       // if the group key is set and hasn't changed, do nothing

--- a/client/scripts/state.ts
+++ b/client/scripts/state.ts
@@ -40,7 +40,8 @@ export interface IApp {
   chain: IChainAdapter<any, any>;
   community: ICommunityAdapter<any, any>;
 
-  chainReady: ReplaySubject<boolean>;
+  chainAdapterReady: ReplaySubject<boolean>;
+  chainModuleReady: ReplaySubject<boolean>;
 
   profiles: ProfilesController;
   comments: CommentsController;
@@ -94,7 +95,8 @@ const app: IApp = {
   chain: null,
   community: null,
 
-  chainReady: new ReplaySubject(1),
+  chainAdapterReady: new ReplaySubject(1),
+  chainModuleReady: new ReplaySubject(1),
 
   profiles: new ProfilesController(),
   comments: new CommentsController(),


### PR DESCRIPTION
## Description
We use a global Subject called "app.chainReady" in dynamic components to wait until the entire chain has initialized before loading additional dynamic data.

This Subject was also being used in the SubstrateAccounts module to handle deferred initialization of the "ChainInfo" module, i.e. the SubstrateChain class. However, the app.chainReady waits for _the entire chain adapter_ to load, not just the `app.chain.chain` module.

To fix this, I separated it into two different Subjects: `app.chainAdapterReady` (same as original `app.chainReady`), and `app.chainModuleReady` (used in Accounts and possibly other future modules to defer initialization).

## Motivation and Context
This bug was causing loading errors on production: the `app.chainReady` wouldn't load until the `SubstrateCollective` module loaded, but the `SubstrateCollective` module assumes that account deferred initializations have already resolved (i.e. that the `app.chainModuleReady` has resolved), so it finds itself unable to query for balances and throws an error.

## How Has This Been Tested?
Reproduced bug in dev environment, verified fix.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] My change should be included in the release notes.
- [ ] I have updated the documentation accordingly.
- [ ] I have linted the code locally prior to submission.
