### PR TITLE
Bug Fix: Add server check to prevent comment creation on "read only" threads

### DIFF
--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -34,6 +34,7 @@ const createComment = async (models, req: UserRequest, res: Response, next: Next
   if (!root_id) {
     return next(new Error('Must provide root_id'));
   }
+
   if ((!text || !text.trim())
       && (!req.body['attachments[]'] || req.body['attachments[]'].length === 0)) {
     return next(new Error('Must provide text or attachment'));
@@ -121,6 +122,13 @@ const createComment = async (models, req: UserRequest, res: Response, next: Next
     });
   } else {
     console.error(`No matching proposal of thread for root_id ${comment.root_id}`);
+  }
+
+  console.dir(proposal);
+  if (!proposal || proposal.read_only) {
+    console.dir('destroying comment');
+    await finalComment.destroy();
+    return next(new Error('Cannot comment when thread is read_only'));
   }
 
   // craft commonwealth url

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -34,7 +34,6 @@ const createComment = async (models, req: UserRequest, res: Response, next: Next
   if (!root_id) {
     return next(new Error('Must provide root_id'));
   }
-
   if ((!text || !text.trim())
       && (!req.body['attachments[]'] || req.body['attachments[]'].length === 0)) {
     return next(new Error('Must provide text or attachment'));
@@ -124,9 +123,7 @@ const createComment = async (models, req: UserRequest, res: Response, next: Next
     console.error(`No matching proposal of thread for root_id ${comment.root_id}`);
   }
 
-  console.dir(proposal);
   if (!proposal || proposal.read_only) {
-    console.dir('destroying comment');
     await finalComment.destroy();
     return next(new Error('Cannot comment when thread is read_only'));
   }


### PR DESCRIPTION
## Description
To maintain the logic order and minimize unidentified problems therewithin, the check verifying if it's okay to comment comes after the initial insertion in the db. This is because the proposal it is attached to is queried later in the logic. To make sure comments aren't orphaned in the database, or show up to users when they're not supposed to be created, if the proposal is read only, the new comment is removed from the database and an error is throw to the client.  

## Motivation and Context
Prevent malicious commenting on read only threads and to enforce expected behavior.

## How Has This Been Tested?
- Set a Thread's read_only to false
- Load thread and client. Should show the commenting UI in client.
- Comment on thread, should work.
- Update Thread's read_only to true in db,
- Without refreshing client, try to comment again and an error will throw.
- Check DB and see the comment is not present.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] My change should be included in the release notes.
- [ ] I have updated the documentation accordingly.
- [x] I have linted the code locally prior to submission.
