### PR TITLE
Alphabetical Tags & Tag Page w/ Title + Description

### DIFF
--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -31,6 +31,16 @@ const DiscussionRow: m.Component<IAttrs> = {
     const lastUpdated = app.comments.lastCommented(proposal)
       || proposal.createdAt;
 
+    const tagSortByName = (a, b) => {
+      if (a.name > b.name) {
+        return 1;
+      } else if (a.name < b.name) {
+        return -1;
+      } else {
+        return 0;
+      }
+    };
+
     return m('.DiscussionRow', { key: proposal.identifier }, [
       m('.discussion-row', [
         m('.discussion-pre', [
@@ -91,7 +101,7 @@ const DiscussionRow: m.Component<IAttrs> = {
               m('.discussion-last-updated', formatLastUpdated(lastUpdated)),
             ]),
             m('.discussion-meta-right', [
-              m('.discussion-tags', proposal.tags.map((tag) => {
+              m('.discussion-tags', proposal.tags.sort((a,b) => tagSortByName(a,b)).map((tag) => {
                 return m(Tag, {
                   intent: 'primary',
                   label: tag.name,

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -117,7 +117,7 @@ const DiscussionsPage: m.Component<IDiscussionPageAttrs, IDiscussionPageState> =
       }
       return m('.discussions-listing.tag-listing', [
         m('h4.tag-name', [
-          tag.name,
+          tag,
           getBackHomeButton(),
         ]),
         list.length === 0

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -115,10 +115,16 @@ const DiscussionsPage: m.Component<IDiscussionPageAttrs, IDiscussionPageState> =
           }
         });
       }
+      const tags = app.tags.getByCommunity(activeEntity.meta.id);
+      const tagObj = tags.find((t) => t.name === tag);
       return m('.discussions-listing.tag-listing', [
         m('h4.tag-name', [
           tag,
           getBackHomeButton(),
+        ]),
+        tagObj.description &&
+        m('h4', [
+          tagObj.description,
         ]),
         list.length === 0
           ? m('.no-threads', 'No threads')


### PR DESCRIPTION
## Description
This PR attends to two Github issues in the Construct-UI-1 Sprint.
- Tags were loading haphazardly on discussion pages => now they render alphabetical.
- Title and description of tag now render on Tag Pages.

## How Has This Been Tested?
- For alphabetical: Tried many different tags and lengths, alpha-numeric combinations, and works as expected.
- For Tag Page: Title always renders now, Description renders conditionally if `Tag.Description` is set.

## Clubhouse tickets/Github issues (if appropriate):
- https://github.com/hicommonwealth/commonwealth-oss/issues/42
- https://github.com/hicommonwealth/commonwealth-oss/issues/45

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] My change should be included in the release notes.
- [ ] I have updated the documentation accordingly.
- [x] I have linted the code locally prior to submission.
