### PR TITLE
Edit Tags from Discussion Row

### DIFF
--- a/client/scripts/views/components/tag_editor.ts
+++ b/client/scripts/views/components/tag_editor.ts
@@ -1,12 +1,13 @@
 import m from 'mithril';
 import $ from 'jquery';
 import { OffchainThread, OffchainTag } from 'models';
-import { Button, Classes, Dialog, Icon, Icons, Tag, TagInput } from 'construct-ui';
+import { Button, Classes, Dialog, Icon, Icons, Tag, TagInput, MenuItem } from 'construct-ui';
 import app from 'state';
 
 interface ITagEditorAttrs {
   thread: OffchainThread;
   onChangeHandler: Function;
+  popoverMenu?: boolean;
 }
 
 const TagWindow: m.Component<{tags: string[], onChangeHandler: Function}> = {
@@ -48,13 +49,16 @@ const TagEditor: m.Component<ITagEditorAttrs, {isOpen: boolean, tags: string[]}>
   },
   view: (vnode) => {
     return m('TagEditor', [
-      m('a', {
-        href: '#',
-        onclick: (e) => { e.preventDefault(); vnode.state.isOpen = true; }
-      }, [
-        // m(Icon, { size: 'xs', name: Icons.TAG, style: 'color: #999;' }),
-        'Edit tags'
-      ]),
+      vnode.attrs.popoverMenu
+        ? m(MenuItem, {
+          label: 'Edit Tags',
+          iconLeft: Icons.TAG,
+          onclick: (e) => { e.preventDefault(); vnode.state.isOpen = true; },
+        })
+        : m('a', {
+          href: '#',
+          onclick: (e) => { e.preventDefault(); vnode.state.isOpen = true; },
+        }, [ 'Edit tags' ]),
       m(Dialog, {
         basic: false,
         closeOnEscapeKey: true,

--- a/client/scripts/views/components/tag_editor.ts
+++ b/client/scripts/views/components/tag_editor.ts
@@ -51,8 +51,9 @@ const TagEditor: m.Component<ITagEditorAttrs, {isOpen: boolean, tags: string[]}>
     return m('TagEditor', [
       vnode.attrs.popoverMenu
         ? m(MenuItem, {
-          label: 'Edit Tags',
           iconLeft: Icons.TAG,
+          fluid: true,
+          label: 'Edit Tags',
           onclick: (e) => { e.preventDefault(); vnode.state.isOpen = true; },
         })
         : m('a', {

--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -12,7 +12,8 @@ import User from 'views/components/widgets/user';
 import { OffchainThread, OffchainThreadKind, OffchainTag } from 'models';
 import MarkdownFormattedText from 'views/components/markdown_formatted_text';
 import QuillFormattedText from 'views/components/quill_formatted_text';
-import TagEditor from '../../components/tag_editor';
+import TagEditor from 'views/components/tag_editor';
+import { isRoleOfCommunity } from 'helpers/roles';
 
 interface IAttrs {
   proposal: OffchainThread;
@@ -93,7 +94,10 @@ const DiscussionRow: m.Component<IAttrs> = {
             ]),
             m('.discussion-meta-right', [
               m('.discussion-tags', [
-                m(PopoverMenu, {
+                (isRoleOfCommunity(app.vm.activeAccount, app.login.addresses, app.login.roles, 'admin', app.activeId())
+                || isRoleOfCommunity(app.vm.activeAccount, app.login.addresses, app.login.roles, 'moderator', app.activeId())
+                || proposal.author === app.vm.activeAccount.address)
+                && m(PopoverMenu, {
                   // class: '.discussion-tags',
                   // style: 'display: inline-block; background-color: #222222;',
                   closeOnContentClick: false,

--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -6,12 +6,13 @@ import { default as moment } from 'moment-twitter';
 
 import app from 'state';
 import { pluralize, slugify, link, externalLink, extractDomain } from 'helpers';
-import { Icon, Icons, Tag } from 'construct-ui';
+import { Icon, Icons, Tag, PopoverMenu } from 'construct-ui';
 
 import User from 'views/components/widgets/user';
-import { OffchainThread, OffchainThreadKind } from 'models';
+import { OffchainThread, OffchainThreadKind, OffchainTag } from 'models';
 import MarkdownFormattedText from 'views/components/markdown_formatted_text';
 import QuillFormattedText from 'views/components/quill_formatted_text';
+import TagEditor from '../../components/tag_editor';
 
 interface IAttrs {
   proposal: OffchainThread;
@@ -91,14 +92,32 @@ const DiscussionRow: m.Component<IAttrs> = {
               m('.discussion-last-updated', formatLastUpdated(lastUpdated)),
             ]),
             m('.discussion-meta-right', [
-              m('.discussion-tags', proposal.tags.map((tag) => {
-                return m(Tag, {
-                  intent: 'primary',
-                  label: tag.name,
-                  size: 'xs',
-                  onclick: (e) => m.route.set(`/${app.activeId()}/discussions/${tag.name}`),
-                }, 'goo');
-              })),
+              m('.discussion-tags', [
+                m(PopoverMenu, {
+                  // class: '.discussion-tags',
+                  // style: 'display: inline-block; background-color: #222222;',
+                  closeOnContentClick: false,
+                  menuAttrs: { size: 'sm', },
+                  content: m(TagEditor, {
+                    thread: proposal,
+                    popoverMenu: true,
+                    onChangeHandler: (tags: OffchainTag[]) => { proposal.tags = tags; m.redraw(); },
+                  }),
+                  trigger: m(Icon, {
+                    name: Icons.SETTINGS,
+                    class: 'discussion-tags',
+                    style: 'margin-right: 6px;'
+                  }),
+                }),
+                proposal.tags.map((tag) => {
+                  return m(Tag, {
+                    intent: 'primary',
+                    label: tag.name,
+                    size: 'xs',
+                    onclick: (e) => m.route.set(`/${app.activeId()}/discussions/${tag.name}`),
+                  }, 'goo');
+                }),
+              ]),
             ]),
           ]),
         ]),


### PR DESCRIPTION
## Description
This PR adds a carat menu to the discussion row for each thread that allows the admin/author to edit the thread's tags.

Outstanding todo: 
- [x] Limit to admin/author

## Motivation and Context
Easier thread management from overview rather than needing to go into each thread to update tags.

## Clubhouse tickets/Github issues (if appropriate):
- https://github.com/hicommonwealth/commonwealth-oss/issues/36

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] My change should be included in the release notes.
- [ ] I have updated the documentation accordingly.
- [x] I have linted the code locally prior to submission.
