### PR TITLE
Edit, Delete, Reply added to carat menu

### DIFF
--- a/client/scripts/controllers/server/comments.ts
+++ b/client/scripts/controllers/server/comments.ts
@@ -167,7 +167,8 @@ class CommentsController {
         jwt: app.login.jwt,
         comment_id: comment.id,
       }).then((result) => {
-        this._store.remove(comment);
+        const existing = this._store.getById(comment.id);
+        this._store.remove(existing);
         resolve(result);
       }).catch((e) => {
         console.error(e);

--- a/client/scripts/views/pages/view_proposal/body.ts
+++ b/client/scripts/views/pages/view_proposal/body.ts
@@ -221,6 +221,7 @@ export const ProposalBodyDelete: m.Component<{ item: OffchainThread | OffchainCo
           if (!confirmed) return;
           (isThread ? app.threads : app.comments).delete(item).then(() => {
             if (isThread) m.route.set(`/${app.activeId()}/`);
+            m.redraw();
             // TODO: set notification bar for 'thread deleted/comment deleted'
           });
         },
@@ -244,6 +245,7 @@ export const ProposalBodyDeleteMenuItem: m.Component<{ item: OffchainThread | Of
         if (!confirmed) return;
         (isThread ? app.threads : app.comments).delete(item).then(() => {
           if (isThread) m.route.set(`/${app.activeId()}/`);
+          m.redraw();
           // TODO: set notification bar for 'thread deleted/comment deleted'
         });
       },
@@ -279,7 +281,9 @@ export const ProposalBodyCancelEdit: m.Component<{ getSetGlobalEditingStatus, pa
 };
 
 export const ProposalBodySaveEdit: m.Component<{
-  item: OffchainThread | OffchainComment<any>, getSetGlobalEditingStatus, parentState
+  item: OffchainThread | OffchainComment<any>,
+  getSetGlobalEditingStatus,
+  parentState,
 }> = {
   view: (vnode) => {
     const { item, getSetGlobalEditingStatus, parentState } = vnode.attrs;
@@ -303,7 +307,7 @@ export const ProposalBodySaveEdit: m.Component<{
               // TODO: set notification bar for 'thread edited' (?)
             });
           } else if (item instanceof OffchainComment) {
-            app.comments.edit(item, itemText).then(() => {
+            app.comments.edit(item, itemText).then((c) => {
               parentState.editing = false;
               getSetGlobalEditingStatus(GlobalStatus.Set, false);
               m.redraw();

--- a/client/scripts/views/pages/view_proposal/body.ts
+++ b/client/scripts/views/pages/view_proposal/body.ts
@@ -27,6 +27,7 @@ import MarkdownFormattedText from 'views/components/markdown_formatted_text';
 import { confirmationModalWithText } from 'views/modals/confirm_modal';
 import VersionHistoryModal from 'views/modals/version_history_modal';
 import ReactionButton, { ReactionType } from 'views/components/reaction_button';
+import { MenuItem } from 'construct-ui';
 
 export enum GlobalStatus {
   Get = 'get',
@@ -129,6 +130,25 @@ export const ProposalBodyReply: m.Component<{ item: OffchainComment<any>, getSet
   }
 };
 
+export const ProposalBodyReplyMenuItem: m.Component<{ item: OffchainComment<any>, getSetGlobalReplyStatus, parentType?, parentState }> = {
+  view: (vnode) => {
+    const { item, parentType, parentState, getSetGlobalReplyStatus } = vnode.attrs;
+    if (!item) return;
+
+    return m(MenuItem, {
+      label: 'Reply',
+      onclick: async (e) => {
+        e.preventDefault();
+        if (getSetGlobalReplyStatus(GlobalStatus.Get) && activeQuillEditorHasText()) {
+          const confirmed = await confirmationModalWithText('Unsubmitted replies will be lost. Continue?')();
+          if (!confirmed) return;
+        }
+        getSetGlobalReplyStatus(GlobalStatus.Set, item.id);
+      },
+    });
+  }
+};
+
 export const ProposalBodyEdit: m.Component<{ item: OffchainThread | OffchainComment<any>, getSetGlobalReplyStatus, getSetGlobalEditingStatus, parentState }> = {
   view: (vnode) => {
     const { item, getSetGlobalEditingStatus, getSetGlobalReplyStatus, parentState } = vnode.attrs;
@@ -158,6 +178,33 @@ export const ProposalBodyEdit: m.Component<{ item: OffchainThread | OffchainComm
   }
 };
 
+export const ProposalBodyEditMenuItem: m.Component<{ item: OffchainThread | OffchainComment<any>, getSetGlobalReplyStatus, getSetGlobalEditingStatus, parentState }> = {
+  view: (vnode) => {
+    const { item, getSetGlobalEditingStatus, getSetGlobalReplyStatus, parentState } = vnode.attrs;
+    if (!item) return;
+    if (item instanceof OffchainThread && item.readOnly) return;
+    const isThread = item instanceof OffchainThread;
+
+    return m(MenuItem, {
+      class: isThread ? 'edit-proposal' : 'edit-comment',
+      onclick: async (e) => {
+        e.preventDefault();
+        parentState.currentText = item instanceof OffchainThread ? item.body : item.text;
+        if (getSetGlobalReplyStatus(GlobalStatus.Get)) {
+          if (activeQuillEditorHasText()) {
+            const confirmed = await confirmationModalWithText('Unsubmitted replies will be lost. Continue?')();
+            if (!confirmed) return;
+          }
+          getSetGlobalReplyStatus(GlobalStatus.Set, false, true);
+        }
+        parentState.editing = true;
+        getSetGlobalEditingStatus(GlobalStatus.Set, true);
+      },
+      label: 'Edit',
+    });
+  }
+};
+
 export const ProposalBodyDelete: m.Component<{ item: OffchainThread | OffchainComment<any> }> = {
   view: (vnode) => {
     const { item } = vnode.attrs;
@@ -179,6 +226,28 @@ export const ProposalBodyDelete: m.Component<{ item: OffchainThread | OffchainCo
         },
       }, 'Delete'),
     ]);
+  }
+};
+
+export const ProposalBodyDeleteMenuItem: m.Component<{ item: OffchainThread | OffchainComment<any> }> = {
+  view: (vnode) => {
+    const { item } = vnode.attrs;
+    if (!item) return;
+    const isThread = item instanceof OffchainThread;
+
+    return m(MenuItem, {
+      label: 'Delete',
+      onclick: async (e) => {
+        e.preventDefault();
+        const confirmed = await confirmationModalWithText(
+          isThread ? 'Delete this entire thread?' : 'Delete this comment?')();
+        if (!confirmed) return;
+        (isThread ? app.threads : app.comments).delete(item).then(() => {
+          if (isThread) m.route.set(`/${app.activeId()}/`);
+          // TODO: set notification bar for 'thread deleted/comment deleted'
+        });
+      },
+    });
   }
 };
 

--- a/client/scripts/views/pages/view_proposal/body.ts
+++ b/client/scripts/views/pages/view_proposal/body.ts
@@ -186,6 +186,7 @@ export const ProposalBodyEditMenuItem: m.Component<{ item: OffchainThread | Offc
     const isThread = item instanceof OffchainThread;
 
     return m(MenuItem, {
+      label: 'Edit',
       class: isThread ? 'edit-proposal' : 'edit-comment',
       onclick: async (e) => {
         e.preventDefault();
@@ -200,7 +201,6 @@ export const ProposalBodyEditMenuItem: m.Component<{ item: OffchainThread | Offc
         parentState.editing = true;
         getSetGlobalEditingStatus(GlobalStatus.Set, true);
       },
-      label: 'Edit',
     });
   }
 };
@@ -307,7 +307,6 @@ export const ProposalBodySaveEdit: m.Component<{
               parentState.editing = false;
               getSetGlobalEditingStatus(GlobalStatus.Set, false);
               m.redraw();
-              // TODO: set notification bar for 'comment edited' (?)
             });
           }
         }

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -57,9 +57,10 @@ import {
 import {
   GlobalStatus, ProposalBodyAuthor, ProposalBodyCreated, ProposalBodyLastEdited, ProposalBodyReply,
   ProposalBodyEdit, ProposalBodyDelete, ProposalBodyCancelEdit, ProposalBodySaveEdit, ProposalBodySpacer,
-  ProposalBodyText, ProposalBodyAttachments, ProposalBodyEditor, ProposalBodyReaction
+  ProposalBodyText, ProposalBodyAttachments, ProposalBodyEditor, ProposalBodyReaction, ProposalBodyEditMenuItem, ProposalBodyDeleteMenuItem, ProposalBodyReplyMenuItem
 } from './body';
 import CreateComment from './create_comment';
+import { PopoverMenu, Icon, Icons } from 'construct-ui';
 
 
 interface IProposalHeaderAttrs {
@@ -129,18 +130,34 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
           proposal instanceof OffchainThread && proposal.versionHistory?.length > 1 && m(ProposalHeaderSpacer),
           m(ProposalHeaderLastEdited, { proposal }),
 
+          // !getSetGlobalEditingStatus(GlobalStatus.Get)
+          //   && isSameAccount(app.vm.activeAccount, author)
+          //   && !vnode.state.editing
+          //   && !proposal.readOnly
+          //   && [
+          //     m(ProposalHeaderSpacer),
+          //     m(ProposalBodyEdit, {
+          //       item: proposal, getSetGlobalReplyStatus, getSetGlobalEditingStatus, parentState: vnode.state
+          //     }),
+          //     m(ProposalHeaderSpacer),
+          //     m(ProposalBodyDelete, { item: proposal }),
+          //   ],
           !getSetGlobalEditingStatus(GlobalStatus.Get)
             && isSameAccount(app.vm.activeAccount, author)
             && !vnode.state.editing
             && !proposal.readOnly
             && [
               m(ProposalHeaderSpacer),
-              m(ProposalBodyEdit, {
-                item: proposal, getSetGlobalReplyStatus, getSetGlobalEditingStatus, parentState: vnode.state
-              }),
-              m(ProposalHeaderSpacer),
-              m(ProposalBodyDelete, { item: proposal }),
-            ],
+              m(PopoverMenu, {
+                closeOnContentClick: true,
+                content: [
+                  m(ProposalBodyEditMenuItem, {
+                    item: proposal, getSetGlobalReplyStatus, getSetGlobalEditingStatus, parentState: vnode.state,
+                  }),
+                  m(ProposalBodyDeleteMenuItem, { item: proposal }),
+                ],
+                trigger: m(Icon, { name: Icons.CHEVRON_DOWN })
+              })],
 
           vnode.state.editing && [
             m(ProposalHeaderSpacer),
@@ -207,38 +224,64 @@ const ProposalComment: m.Component<IProposalCommentAttrs, IProposalCommentState>
         comment.versionHistory?.length > 1 && m(ProposalBodySpacer),
         m(ProposalBodyLastEdited, { item: comment }),
 
+        // !vnode.state.editing
+        //   && app.vm.activeAccount
+        //   && !getSetGlobalEditingStatus(GlobalStatus.Get)
+        //   && app.vm.activeAccount?.chain.id === comment.authorChain
+        //   && app.vm.activeAccount?.address === comment.author
+        //   && [
+        //     m(ProposalBodySpacer),
+        //     m(ProposalBodyEdit, {
+        //       item: comment,
+        //       getSetGlobalReplyStatus,
+        //       getSetGlobalEditingStatus,
+        //       parentState: vnode.state
+        //     }),
+        //     m(ProposalBodySpacer),
+        //     m(ProposalBodyDelete, { item: comment }),
+        //   ],
+
         !vnode.state.editing
-          && app.vm.activeAccount
-          && !getSetGlobalEditingStatus(GlobalStatus.Get)
-          && app.vm.activeAccount?.chain.id === comment.authorChain
-          && app.vm.activeAccount?.address === comment.author
-          && [
-            m(ProposalBodySpacer),
-            m(ProposalBodyEdit, {
-              item: comment,
-              getSetGlobalReplyStatus,
-              getSetGlobalEditingStatus,
-              parentState: vnode.state
-            }),
-            m(ProposalBodySpacer),
-            m(ProposalBodyDelete, { item: comment }),
-          ],
+        && app.vm.activeAccount
+        && !getSetGlobalEditingStatus(GlobalStatus.Get)
+        && app.vm.activeAccount?.chain.id === comment.authorChain
+        && app.vm.activeAccount?.address === comment.author
+        && [
+          m(ProposalBodySpacer),
+          m(PopoverMenu, {
+            closeOnContentClick: true,
+            content: [
+              m(ProposalBodyEditMenuItem, {
+                item: comment, getSetGlobalReplyStatus, getSetGlobalEditingStatus, parentState: vnode.state,
+              }),
+              m(ProposalBodyDeleteMenuItem, { item: comment }),
+              parentType === CommentParent.Proposal // For now, we are limiting threading to 1 level deep
+              && m(ProposalBodyReplyMenuItem, {
+                item: comment,
+                getSetGlobalReplyStatus,
+                parentType,
+                parentState: vnode.state,
+              }),
+            ],
+            trigger: m(Icon, { name: Icons.CHEVRON_DOWN })
+          })
+        ],
 
         // For now, we are limiting threading to 1 level deep
         // Comments whose parents are other comments should not display the reply option
-        !vnode.state.editing
-          && app.vm.activeAccount
-          && !getSetGlobalEditingStatus(GlobalStatus.Get)
-          && parentType === CommentParent.Proposal
-          && [
-            m(ProposalBodySpacer),
-            m(ProposalBodyReply, {
-              item: comment,
-              getSetGlobalReplyStatus,
-              parentType,
-              parentState: vnode.state,
-            }),
-          ],
+        // !vnode.state.editing
+        //   && app.vm.activeAccount
+        //   && !getSetGlobalEditingStatus(GlobalStatus.Get)
+        //   && parentType === CommentParent.Proposal
+        //   && [
+        //     m(ProposalBodySpacer),
+        //     m(ProposalBodyReply, {
+        //       item: comment,
+        //       getSetGlobalReplyStatus,
+        //       parentType,
+        //       parentState: vnode.state,
+        //     }),
+        //   ],
 
         vnode.state.editing && [
           m(ProposalBodySpacer),

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -93,6 +93,7 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
         ? app.chain.accounts.get(proposal.author)
         : app.community.accounts.get(proposal.author, proposal.authorChain))
       : proposal.author;
+    console.dir(getSetGlobalEditingStatus(GlobalStatus.Get));
 
     return m('.ProposalHeader', {
       class: `proposal-${proposal.slug}`
@@ -145,7 +146,6 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
           !getSetGlobalEditingStatus(GlobalStatus.Get)
             && isSameAccount(app.vm.activeAccount, author)
             && !vnode.state.editing
-            && !proposal.readOnly
             && [
               m(ProposalHeaderSpacer),
               m(PopoverMenu, {

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -93,7 +93,6 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
         ? app.chain.accounts.get(proposal.author)
         : app.community.accounts.get(proposal.author, proposal.authorChain))
       : proposal.author;
-    console.dir(getSetGlobalEditingStatus(GlobalStatus.Get));
 
     return m('.ProposalHeader', {
       class: `proposal-${proposal.slug}`
@@ -131,18 +130,6 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
           proposal instanceof OffchainThread && proposal.versionHistory?.length > 1 && m(ProposalHeaderSpacer),
           m(ProposalHeaderLastEdited, { proposal }),
 
-          // !getSetGlobalEditingStatus(GlobalStatus.Get)
-          //   && isSameAccount(app.vm.activeAccount, author)
-          //   && !vnode.state.editing
-          //   && !proposal.readOnly
-          //   && [
-          //     m(ProposalHeaderSpacer),
-          //     m(ProposalBodyEdit, {
-          //       item: proposal, getSetGlobalReplyStatus, getSetGlobalEditingStatus, parentState: vnode.state
-          //     }),
-          //     m(ProposalHeaderSpacer),
-          //     m(ProposalBodyDelete, { item: proposal }),
-          //   ],
           !getSetGlobalEditingStatus(GlobalStatus.Get)
             && isSameAccount(app.vm.activeAccount, author)
             && !vnode.state.editing
@@ -156,6 +143,7 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
                   }),
                   m(ProposalBodyDeleteMenuItem, { item: proposal }),
                 ],
+                transitionDuration: 0,
                 trigger: m(Icon, { name: Icons.CHEVRON_DOWN })
               })],
 
@@ -203,11 +191,12 @@ interface IProposalCommentAttrs {
   getSetGlobalReplyStatus: CallableFunction;
   parent: AnyProposal | OffchainComment<any> | OffchainThread;
   proposal: AnyProposal | OffchainThread;
+  callback?: Function;
 }
 
 const ProposalComment: m.Component<IProposalCommentAttrs, IProposalCommentState> = {
   view: (vnode) => {
-    const { comment, getSetGlobalEditingStatus, getSetGlobalReplyStatus, parent, proposal } = vnode.attrs;
+    const { comment, getSetGlobalEditingStatus, getSetGlobalReplyStatus, parent, proposal, callback } = vnode.attrs;
     if (!comment) return;
     const parentType = comment.parentComment ? CommentParent.Comment : CommentParent.Proposal;
 
@@ -215,7 +204,8 @@ const ProposalComment: m.Component<IProposalCommentAttrs, IProposalCommentState>
       + `${proposal.identifier}-${slugify(proposal.title)}?comment=${comment.id}`;
 
     return m('.ProposalComment', {
-      class: `${parentType}-child comment-${comment.id}`
+      class: `${parentType}-child comment-${comment.id}`,
+      onchange: () => m.redraw(),
     }, [
       m('.comment-body-meta', [
         m(ProposalBodyAuthor, { comment }),
@@ -263,6 +253,7 @@ const ProposalComment: m.Component<IProposalCommentAttrs, IProposalCommentState>
                 parentState: vnode.state,
               }),
             ],
+            transitionDuration: 0,
             trigger: m(Icon, { name: Icons.CHEVRON_DOWN })
           })
         ],
@@ -287,7 +278,7 @@ const ProposalComment: m.Component<IProposalCommentAttrs, IProposalCommentState>
           m(ProposalBodySpacer),
           m(ProposalBodyCancelEdit, { getSetGlobalEditingStatus, parentState: vnode.state }),
           m(ProposalBodySpacer),
-          m(ProposalBodySaveEdit, { item: comment, getSetGlobalEditingStatus, parentState: vnode.state }),
+          m(ProposalBodySaveEdit, { item: comment, getSetGlobalEditingStatus, parentState: vnode.state, }),
         ],
       ]),
       m('.comment-body-content', [
@@ -397,7 +388,7 @@ const ProposalComments: m.Component<IProposalCommentsAttrs, IProposalCommentsSta
     };
 
     return m('.ProposalComments', {
-      oncreate: (vnode2) => { vnode.state.dom = vnode2.dom; }
+      oncreate: (vnode2) => { vnode.state.dom = vnode2.dom; },
     }, [
       // show comments
       comments

--- a/server/routes/editComment.ts
+++ b/server/routes/editComment.ts
@@ -6,8 +6,6 @@ import { UserRequest } from '../types';
 import { getProposalUrl } from '../../shared/utils';
 
 const editComment = async (models, req: UserRequest, res: Response, next: NextFunction) => {
-  const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.body, req.user, next);
-  const author = await lookupAddressIsOwnedByUser(models, req, next);
 
   if (!req.user) {
     return next(new Error('Not logged in'));

--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -49,8 +49,8 @@ const editThread = async (models, req: UserRequest, res: Response, next: NextFun
     arr.unshift(version_history);
     thread.version_history = arr;
     thread.body = body;
-    if (read_only) thread.read_only = !thread.read_only;
-    if (privacy) thread.private = false;
+    if (read_only !== 'false') thread.read_only = !thread.read_only;
+    if (privacy !== 'false') thread.private = false;
     await thread.save();
     attachFiles();
     const finalThread = await models.OffchainThread.findOne({


### PR DESCRIPTION
## Description
This PR moves the Edit, Delete, Reply creates new MenuItem components from previous link-button components. Old components are still present as they may be useful as well. MenuItems are added to Carat menu in the place that the previous link-buttons resided. 

### Question:
- I made separate but very similar components from the link components. These could be combined into a single component that renders differently on property. Is this preferred style across the board? Or case-by-case?

## Related Issue for another PR: 
1st Level Comments don't redraw upon edit/delete. 2nd Level Comments, comments on comments, work as expected.
- https://github.com/hicommonwealth/commonwealth-oss/issues/109

## Clubhouse tickets/Github issues (if appropriate):
- https://github.com/hicommonwealth/commonwealth-oss/issues/35

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] My change should be included in the release notes.
- [ ] I have updated the documentation accordingly.
- [x] I have linted the code locally prior to submission.
