### PR TITLE
Fixes signaling voting actions and display bug

### DIFF
--- a/client/scripts/controllers/chain/edgeware/signaling.ts
+++ b/client/scripts/controllers/chain/edgeware/signaling.ts
@@ -192,12 +192,13 @@ extends Proposal<ApiRx, SubstrateCoin, IEdgewareSignalingProposal, IEdgewareSign
   }
 
   public get votingType() {
-    // TODO: support ranked-choice votes
-    return (this.data.voteType.toString() === 'binary')
-      ? VotingType.SimpleYesNoVoting // TODO: generalize this to what the options are
-      : (this.data.voteType.toString() === 'multioption')
-      ? VotingType.MultiOptionVoting
-      : VotingType.RankedChoiceVoting;
+    if (this.data.voteType.toString().toLowerCase() === 'binary') {
+      return VotingType.SimpleYesNoVoting;
+    } else if (this.data.voteType.toString().toLowerCase() === 'multioption') {
+      return VotingType.MultiOptionVoting;
+    } else {
+      return VotingType.RankedChoiceVoting;
+    }
   }
   public get votingUnit() {
     return VotingUnit.CoinVote;

--- a/client/scripts/views/components/proposals/voting_actions.ts
+++ b/client/scripts/views/components/proposals/voting_actions.ts
@@ -46,7 +46,6 @@ const ProposalExtensions: m.Component<{ proposal, callback?, setConviction? }> =
     const proposal = vnode.attrs.proposal;
     const callback = vnode.attrs.callback;
     const user: SubstrateAccount = app.vm.activeAccount as SubstrateAccount;
-
     if (vnode.attrs.proposal instanceof EdgewareSignalingProposal) {
       const advanceSignalingProposal = (e) => {
         e.preventDefault();

--- a/client/scripts/views/pages/new_signaling.ts
+++ b/client/scripts/views/pages/new_signaling.ts
@@ -48,10 +48,13 @@ export const NewSignalingPage: m.Component<{}, ISignalingPageState> = {
       m.route.set(`/${app.activeChainId()}/login`, {}, { replace: true });
       return;
     }
-    if (app.chain.class !== ChainClass.Edgeware) {
-      notifyInfo('Can only create signaling proposals on Edgeware');
-      m.route.set(`/${app.activeChainId()}/discussions`);
-      return;
+
+    if (app.chain) {
+      if (app.chain.class !== ChainClass.Edgeware) {
+        notifyInfo('Can only create signaling proposals on Edgeware');
+        m.route.set(`/${app.activeChainId()}/discussions`);
+        return;
+      }
     }
 
     const author = app.vm.activeAccount;

--- a/client/scripts/views/pages/proposals.ts
+++ b/client/scripts/views/pages/proposals.ts
@@ -108,7 +108,7 @@ const ProposalsPage: m.Component<{}> = {
           'Treasury proposals',
         ]),
         visibleTreasuryProposals &&
-          visibleTreasuryProposals.map((proposal) => m(ProposalRow, { proposal: proposal })),
+          visibleTreasuryProposals.map((proposal) => m(ProposalRow, { proposal })),
         //
         visibleCosmosProposals && m('h4.proposals-subheader', [
           'Cosmos proposals',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Signaling proposals weren't showing the proper voting type.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Things were broken.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Testing by running local Edgeware (3.0.5-testnet version) and creating signaling polls, starting them, voting on them. Previously all proposals resolved to "rankedchoice" votes which are unimplemented still.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have linted the code locally prior to submission.
