### PR TITLE
Infinite Scroll

### DIFF
--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -44,7 +44,7 @@ const DiscussionsPage: m.Component<IDiscussionPageAttrs, IDiscussionPageState> =
       Scope: app.activeId(),
     });
     // Infinite Scroll
-    $(window).on('scroll', () => {
+    const onscroll = _.debounce(() => {
       const scrollHeight = $(document).height();
       const scrollPos = $(window).height() + $(window).scrollTop();
       if (scrollPos > (scrollHeight - 400)) {
@@ -53,7 +53,8 @@ const DiscussionsPage: m.Component<IDiscussionPageAttrs, IDiscussionPageState> =
           m.redraw();
         }
       }
-    });
+    }, 400);
+    $(window).on('scroll', onscroll);
   },
   view: (vnode) => {
     const activeEntity = app.community ? app.community : app.chain;

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import m from 'mithril';
 import mixpanel from 'mixpanel-browser';
 import moment from 'moment-twitter';
+import $ from 'jquery';
 
 import app from 'state';
 import { updateRoute } from 'app';
@@ -32,6 +33,8 @@ interface IDiscussionPageState {
   lookback?: number;
   postsDepleted?: boolean;
   lastVisitedUpdated?: boolean;
+  hasOlderPosts?: boolean;
+  defaultLookback: number;
 }
 
 const DiscussionsPage: m.Component<IDiscussionPageAttrs, IDiscussionPageState> = {
@@ -40,7 +43,29 @@ const DiscussionsPage: m.Component<IDiscussionPageAttrs, IDiscussionPageState> =
       'Page Name': 'DiscussionsPage',
       Scope: app.activeId(),
     });
-    if (m.route.param('lookback')) vnode.state.lookback = +m.route.param('lookback');
+    // Infinite Scroll
+    $(window).on('scroll', () => {
+      const scrollHeight = $(document).height();
+      const scrollPos = $(window).height() + $(window).scrollTop();
+      if (scrollPos > (scrollHeight - 400)) {
+        if (vnode.state.hasOlderPosts && !vnode.state.postsDepleted) {
+          vnode.state.lookback += vnode.state.defaultLookback;
+          m.redraw();
+        }
+      }
+    });
+
+    // const options = {
+    //   root: null, // Page as root
+    //   rootMargin: '0px',
+    //   threshold: 1.0
+    // };
+    // const observer = new IntersectionObserver(
+    //   handleObserver.bind(this),
+    //   options
+    // );
+    // //Observ the `loadingRef`
+    // observer.observe(loadingRef);
   },
   view: (vnode) => {
     const activeEntity = app.community ? app.community : app.chain;
@@ -144,7 +169,7 @@ const DiscussionsPage: m.Component<IDiscussionPageAttrs, IDiscussionPageState> =
         return ago - (ago % week);
       });
       const weekIndexes = Object.keys(proposalsByWeek);
-      const hasOlderPosts = weekIndexes.findIndex((msecAgo) => +msecAgo > vnode.state.lookback) !== -1;
+      vnode.state.hasOlderPosts = weekIndexes.findIndex((msecAgo) => +msecAgo > vnode.state.lookback) !== -1;
 
       // select the appropriate lastVisited timestamp from the chain||community & convert to Moment
       // for easy comparison with weekly indexes' msecAgo
@@ -160,7 +185,8 @@ const DiscussionsPage: m.Component<IDiscussionPageAttrs, IDiscussionPageState> =
         .map((str) => Number(str)));
 
       // determine lookback length
-      const defaultLookback = 20;
+      vnode.state.defaultLookback = 20;
+      const { defaultLookback } = vnode.state;
       vnode.state.lookback = (!vnode.state.lookback || isNaN(vnode.state.lookback))
         ? defaultLookback
         : vnode.state.lookback;
@@ -211,18 +237,7 @@ const DiscussionsPage: m.Component<IDiscussionPageAttrs, IDiscussionPageState> =
           m('.no-threads', 'No threads'),
         ],
         allProposals.length !== 0
-        && getRecentPostsSortedByWeek(),
-        hasOlderPosts
-        && !vnode.state.postsDepleted
-        && m('a.extra-items.discussion-group-wrap', {
-          href: '#',
-          onclick: (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            vnode.state.lookback += defaultLookback;
-            updateRoute(m.route.get(), { lookback: vnode.state.lookback });
-          },
-        }, 'Show more'),
+        && getRecentPostsSortedByWeek()
       ]);
     };
 

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -54,18 +54,6 @@ const DiscussionsPage: m.Component<IDiscussionPageAttrs, IDiscussionPageState> =
         }
       }
     });
-
-    // const options = {
-    //   root: null, // Page as root
-    //   rootMargin: '0px',
-    //   threshold: 1.0
-    // };
-    // const observer = new IntersectionObserver(
-    //   handleObserver.bind(this),
-    //   options
-    // );
-    // //Observ the `loadingRef`
-    // observer.observe(loadingRef);
   },
   view: (vnode) => {
     const activeEntity = app.community ? app.community : app.chain;


### PR DESCRIPTION
## Description
This change moves us away from the ["Show more" button + route lookback] system, used previously for forum homepages, and toward a button-less, param-less infinite scroll.

## How Has This Been Tested?
Has been trialed on both communities and chains, in both Chrome and Firefox, logged in and logged out, in communities with >20 posts (the default lookback) and <20 posts (i.e. those which should trigger a scroll and those that shouldn't). Behavior was as desired in all cases.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)