### PR TITLE
Better tabulation of unread forum content

### DIFF
--- a/client/scripts/views/pages/home.ts
+++ b/client/scripts/views/pages/home.ts
@@ -10,7 +10,7 @@ const ChainCard : m.Component<{ chain, nodeList, justJoinedChains }> = {
   view: (vnode) => {
     const { chain, nodeList, justJoinedChains } = vnode.attrs;
     const visitedChain = !!app.login.unseenPosts[chain];
-    const newThreads = app.login.unseenPosts[chain]?.threads ? app.login.unseenPosts[chain]?.threads : 0;
+    const newThreads = app.login.unseenPosts[chain]?.activePosts || 0;
     return link('a.home-card.ChainCard', `/${chain}/`, [
       m(ChainIcon, { chain: nodeList[0].chain }),
       m('.chain-info', [
@@ -23,7 +23,7 @@ const ChainCard : m.Component<{ chain, nodeList, justJoinedChains }> = {
       ],
       app.isLoggedIn() && m('.chain-membership', [
         m(MembershipButton, {
-          chain: chain,
+          chain,
           onMembershipChanged: (created) => {
             if (created) justJoinedChains.push(chain);
           }

--- a/server/routes/status.ts
+++ b/server/routes/status.ts
@@ -118,7 +118,15 @@ const status = async (models, req: UserRequest, res: Response, next: NextFunctio
         created_at: { [Op.gt]: new Date(time as string) }
       }
     });
+    const threads = [];
+    threadNum.rows.forEach((r) => {
+      if (!threads.includes(`discussion_${r.id}`)) threads.push(`discussion_${r.id}`);
+    });
+    commentNum.rows.forEach((r) => {
+      if (!threads.includes(r.root_id)) threads.push(r.root_id);
+    });
     unseenPosts[name] = {
+      'activePosts': threads.length,
       'threads': threadNum.count,
       'comments': commentNum.count
     };

--- a/server/routes/status.ts
+++ b/server/routes/status.ts
@@ -118,15 +118,18 @@ const status = async (models, req: UserRequest, res: Response, next: NextFunctio
         created_at: { [Op.gt]: new Date(time as string) }
       }
     });
-    const threads = [];
+    const activeThreads = [];
     threadNum.rows.forEach((r) => {
-      if (!threads.includes(`discussion_${r.id}`)) threads.push(`discussion_${r.id}`);
+      if (!activeThreads.includes(r.id)) activeThreads.push(r.id);
     });
     commentNum.rows.forEach((r) => {
-      if (!threads.includes(r.root_id)) threads.push(r.root_id);
+      if (r.root_id.includes('discussion')) {
+        const id = Number(r.root_id.split('_')[1]);
+        if (!activeThreads.includes(id)) activeThreads.push(id);
+      }
     });
     unseenPosts[name] = {
-      'activePosts': threads.length,
+      'activePosts': activeThreads.length,
       'threads': threadNum.count,
       'comments': commentNum.count
     };


### PR DESCRIPTION
The landing page indicator showed users how many new threads had been created in a community since their last visit. This updated indicator displays how many threads were "active" since last visit, which is to say, were either created or commented on. 

## How Has This Been Tested?
Tested by inspecting the database, console-logging the inputs/outputs of the functions that count activePosts for various communities, and testing different DB states for proper counting.