### PR TITLE
Add Tags on Tag Page

### DIFF
--- a/client/scripts/controllers/chain/community/main.ts
+++ b/client/scripts/controllers/chain/community/main.ts
@@ -19,6 +19,7 @@ class Community extends ICommunityAdapter<Coin, OffchainAccount> {
     await this.app.threads.refreshAll(null, this.id, true);
     await this.app.comments.refreshAll(null, this.id, true);
     await this.app.reactions.refreshAll(null, this.id, true);
+    await this.app.tags.refreshAll(this.meta.id);
     this._serverLoaded = true;
     this._loaded = true;
   }

--- a/client/scripts/controllers/server/tags.ts
+++ b/client/scripts/controllers/server/tags.ts
@@ -77,7 +77,6 @@ class TagsController {
         this._store.remove(this._store.getById(result.id));
       }
       this._store.add(result);
-      console.dir(this._store);
       return result;
     } catch (err) {
       console.log('Failed to edit tag');

--- a/client/scripts/controllers/server/tags.ts
+++ b/client/scripts/controllers/server/tags.ts
@@ -62,6 +62,31 @@ class TagsController {
     }
   }
 
+  public async add(name: string,) {
+    try {
+      const chainOrCommObj = (app.activeChainId())
+        ? { 'chain': app.activeChainId() }
+        : { 'community': app.activeCommunityId() };
+      const response = await $.post(`${app.serverUrl()}/createTag`, {
+        ...chainOrCommObj,
+        'name': name,
+        'jwt': app.login.jwt,
+      });
+      const result = modelFromServer(response.result);
+      if (this._store.getById(result.id)) {
+        this._store.remove(this._store.getById(result.id));
+      }
+      this._store.add(result);
+      console.dir(this._store);
+      return result;
+    } catch (err) {
+      console.log('Failed to edit tag');
+      throw new Error((err.responseJSON && err.responseJSON.error)
+        ? err.responseJSON.error
+        : 'Failed to edit tag');
+    }
+  }
+
   public async remove(tag) {
     try {
       const response = await $.post(`${app.serverUrl()}/deleteTag`, {

--- a/client/scripts/views/components/sidebar/tag_selector.ts
+++ b/client/scripts/views/components/sidebar/tag_selector.ts
@@ -13,6 +13,7 @@ import { OffchainThreadKind } from 'models';
 import EditTagModal from 'views/modals/edit_tag_modal';
 import PageLoading from 'views/pages/loading';
 import { isCommunityAdmin } from 'views/pages/discussions/roles';
+import { inputModalWithText } from '../../modals/input_modal';
 
 interface ITagRowAttrs {
   count: number,
@@ -50,7 +51,7 @@ const TagRow: m.Component<ITagRowAttrs, {}> = {
         m('span.tag-name', name),
       ],
       contentRight: [
-        !hideEditButton && m('.tag-count', pluralize(count, 'post')),
+        !hideEditButton && count && m('.tag-count', pluralize(count, 'post')),
         !hideEditButton && isCommunityAdmin() && m(Button, {
           class: 'edit-button',
           size: 'xs',
@@ -123,6 +124,27 @@ export const getTagListing = (params: IGetTagListingParams) => {
     });
   });
 
+  const threadlessTags = app.tags.store.getAll().map((tag) => {
+    if (featuredTagIds.includes(`${tag.id}`)) {
+      if (!featuredTags[`${tag.id}`]) {
+        featuredTags[tag.name] = {
+          count: null,
+          description: tag.description,
+          featured_order: featuredTagIds.indexOf(`${tag.id}`),
+          id: tag.id,
+          name: tag.name,
+        };
+      }
+    } else if (!otherTags[tag.name]) {
+      otherTags[tag.name] = {
+        count: null,
+        description: tag.description,
+        id: tag.id,
+        name: tag.name,
+      };
+    }
+  });
+
   const otherTagListing = Object.keys(otherTags)
     .sort((a, b) => otherTags[b].count - otherTags[a].count)
     .map((name, idx) => m(TagRow, {
@@ -153,6 +175,22 @@ export const getTagListing = (params: IGetTagListingParams) => {
     : [];
 
   return ({ featuredTagListing, otherTagListing });
+};
+
+const NewTagButton: m.Component = {
+  view: (vnode) => {
+    return m(Button, {
+      class: '',
+      label: 'Create New Tag',
+      iconLeft: Icons.PLUS,
+      onclick: async (e) => {
+        e.preventDefault();
+        const tag = await inputModalWithText('New Tag:')();
+        if (!tag) return;
+        app.tags.add(tag).then(() => { m.redraw(); });
+      },
+    });
+  },
 };
 
 const TagSelector: m.Component<{
@@ -198,6 +236,7 @@ const TagSelector: m.Component<{
       }, featuredTagListing),
       showFullListing && m('h4', featuredTagListing.length > 0 ? 'Other tags' : 'Tags'),
       showFullListing && !!otherTagListing.length && m(List, { class: 'other-tag-list' }, otherTagListing),
+      showFullListing && m(NewTagButton),
       !showFullListing
         && (app.community || app.chain)
         && m(List, [

--- a/client/scripts/views/components/sidebar/tag_selector.ts
+++ b/client/scripts/views/components/sidebar/tag_selector.ts
@@ -126,7 +126,7 @@ export const getTagListing = (params: IGetTagListingParams) => {
 
   const threadlessTags = app.tags.store.getAll().map((tag) => {
     if (featuredTagIds.includes(`${tag.id}`)) {
-      if (!featuredTags[`${tag.id}`]) {
+      if (!featuredTags[`${tag.name}`]) {
         featuredTags[tag.name] = {
           count: null,
           description: tag.description,

--- a/client/scripts/views/modals/input_modal.ts
+++ b/client/scripts/views/modals/input_modal.ts
@@ -3,6 +3,7 @@ import 'modals/input_modal.scss';
 import { default as m } from 'mithril';
 import { default as $ } from 'jquery';
 import app from 'state';
+import { Button } from 'construct-ui';
 
 const InputModal = {
   confirmExit: async () => true,
@@ -24,7 +25,8 @@ const InputModal = {
         }),
       ]),
       m('.compact-modal-actions', [
-        m('button', {
+        m(Button, {
+          label: 'Submit',
           type: 'submit',
           onclick: (e) => {
             e.preventDefault();
@@ -34,13 +36,14 @@ const InputModal = {
               $(vnode.dom).trigger('modalexit');
             }, 0);
           }
-        }, 'Submit'),
-        m('button', {
+        }),
+        m(Button, {
+          label: 'Cancel',
           onclick: (e) => {
             e.preventDefault();
             $(vnode.dom).trigger('modalexit');
           }
-        }, 'Cancel'),
+        }),
       ]),
     ]);
   }

--- a/client/scripts/views/pages/subscriptions.ts
+++ b/client/scripts/views/pages/subscriptions.ts
@@ -217,7 +217,6 @@ const ActiveSubscriptions: m.Component<{}, IActiveSubscriptionsState> = {
       });
       m.redraw();
     }, (error) => {
-      console.dir(error);
       m.route.set('/');
     });
   },

--- a/server/router.ts
+++ b/server/router.ts
@@ -73,6 +73,7 @@ import updateProfile from './routes/updateProfile';
 import writeUserSetting from './routes/writeUserSetting';
 import sendFeedback from './routes/sendFeedback';
 import logout from './routes/logout';
+import createTag from './routes/createTag';
 import updateTags from './routes/updateTags';
 import editTag from './routes/editTag';
 import deleteTag from './routes/deleteTag';
@@ -129,6 +130,7 @@ function setupRouter(app, models, fetcher, viewCountCache: ViewCountCache) {
   router.get('/bulkComments', bulkComments.bind(this, models));
 
   // offchain tags
+  router.post('/createTag', passport.authenticate('jwt', { session: false }), createTag.bind(this, models));
   router.post('/updateTags', passport.authenticate('jwt', { session: false }), updateTags.bind(this, models));
   router.post('/editTag', passport.authenticate('jwt', { session: false }), editTag.bind(this, models));
   router.post('/deleteTag', passport.authenticate('jwt', { session: false }), deleteTag.bind(this, models));

--- a/server/routes/createTag.ts
+++ b/server/routes/createTag.ts
@@ -1,9 +1,8 @@
-import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 import { Response, NextFunction } from 'express';
+import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 import { UserRequest } from '../types';
 
 const createTag = async (models, req: UserRequest, res: Response, next: NextFunction) => {
-  console.dir(req.body);
   const { Op } = models.sequelize;
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.body, req.user, next);
   if (!chain && !community) return next(new Error('Invalid chain or community'));

--- a/server/routes/createTag.ts
+++ b/server/routes/createTag.ts
@@ -1,0 +1,29 @@
+import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
+import { Response, NextFunction } from 'express';
+import { UserRequest } from '../types';
+
+const createTag = async (models, req: UserRequest, res: Response, next: NextFunction) => {
+  console.dir(req.body);
+  const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.body, req.user, next);
+  if (!chain && !community) return next(new Error('Invalid chain or community'));
+  if (chain && community) return next(new Error('Invalid chain or community'));
+  if (!req.user) return next(new Error('Not logged in'));
+  if (!req.body.name) return next(new Error('Tag name required'));
+
+  const options = community ? {
+    name: req.body.name,
+    community_id: community.id,
+  } : {
+    name: req.body.name,
+    chain_id: chain.id,
+  };
+
+  const newTag = await models.OffchainTag.findOrCreate({
+    where: options,
+    default: options,
+  });
+
+  return res.json({ status: 'Success', result: newTag[0] });
+};
+
+export default createTag;

--- a/test/unit/api/tags.spec.ts
+++ b/test/unit/api/tags.spec.ts
@@ -51,7 +51,6 @@ describe('Tag Tests', () => {
           jwt: adminJWT,
         });
       expect(res.body.result).to.not.be.null;
-      console.dir(res.body);
       expect(res.body).to.not.be.null;
       expect(res.body.status).to.be.equal('Success');
       expect(res.body.result).to.not.be.null;


### PR DESCRIPTION
## Description
This PR adds a button that opens a modal to add a new tag to a community prior to being use on a thread. It also adds the related route, `/createTag`.

## Clubhouse tickets/Github issues (if appropriate):
- #41 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] My change should be included in the release notes.
- [ ] I have updated the documentation accordingly.
- [x] I have linted the code locally prior to submission.
