### PR TITLE
Add check that user-owned addresses are verified

### DIFF
--- a/server/routes/deleteComment.ts
+++ b/server/routes/deleteComment.ts
@@ -17,7 +17,7 @@ const deleteComment = async (models, req: UserRequest, res: Response, next: Next
       where: { id: req.body.comment_id, },
       include: [ models.Address ],
     });
-    if (userOwnedAddresses.map((addr) => addr.id).indexOf(comment.address_id) === -1) {
+    if (userOwnedAddresses.filter((addr) => addr.verified).map((addr) => addr.id).indexOf(comment.address_id) === -1) {
       return next(new Error('Not owned by this user'));
     }
     // actually delete

--- a/server/routes/deleteCommunity.ts
+++ b/server/routes/deleteCommunity.ts
@@ -16,7 +16,7 @@ const deleteCommunity = async (models, req: UserRequest, res: Response, next: Ne
     const community = await models.OffchainCommunity.findOne({
       where: { id: req.body.community_id },
     });
-    if (userOwnedAddresses.map((addr) => addr.id).indexOf(community.creator_id) === -1) {
+    if (userOwnedAddresses.filter((addr) => addr.verified).map((addr) => addr.id).indexOf(community.creator_id) === -1) {
       return next(new Error('Only the original creator can delete this community'));
     }
     const communityTags = await community.getTags();

--- a/server/routes/deleteReaction.ts
+++ b/server/routes/deleteReaction.ts
@@ -17,7 +17,7 @@ const deleteReaction = async (models, req: UserRequest, res: Response, next: Nex
       where: { id: req.body.reaction_id, },
       include: [ models.Address ],
     });
-    if (userOwnedAddresses.map((addr) => addr.id).indexOf(reaction.address_id) === -1) {
+    if (userOwnedAddresses.filter((addr) => addr.verified).map((addr) => addr.id).indexOf(reaction.address_id) === -1) {
       return next(new Error('Not owned by this user'));
     }
     // actually delete

--- a/server/routes/deleteThread.ts
+++ b/server/routes/deleteThread.ts
@@ -16,7 +16,7 @@ const deleteThread = async (models, req: UserRequest, res: Response, next: NextF
     const thread = await models.OffchainThread.findOne({
       where: { id: req.body.thread_id, }
     });
-    if (userOwnedAddresses.map((addr) => addr.id).indexOf(thread.author_id) === -1) {
+    if (userOwnedAddresses.filter((addr) => addr.verified).map((addr) => addr.id).indexOf(thread.author_id) === -1) {
       return next(new Error('Not owned by this user'));
     }
     const associatedTags = await thread.getTags();

--- a/server/routes/editComment.ts
+++ b/server/routes/editComment.ts
@@ -42,7 +42,7 @@ const editComment = async (models, req: UserRequest, res: Response, next: NextFu
       where: { id: req.body.id },
     });
 
-    if (userOwnedAddresses.map((addr) => addr.id).indexOf(comment.address_id) === -1) {
+    if (userOwnedAddresses.filter((addr) => addr.verified).map((addr) => addr.id).indexOf(comment.address_id) === -1) {
       return next(new Error('Not owned by this user'));
     }
     const arr = comment.version_history;

--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -44,7 +44,7 @@ const editThread = async (models, req: UserRequest, res: Response, next: NextFun
     const thread = await models.OffchainThread.findOne({
       where: { id: thread_id },
     });
-    if (userOwnedAddresses.map((addr) => addr.id).indexOf(thread.author_id) === -1) {
+    if (userOwnedAddresses.filter((addr) => addr.verified).map((addr) => addr.id).indexOf(thread.author_id) === -1) {
       return next(new Error('Not owned by this user'));
     }
     const arr = thread.version_history;


### PR DESCRIPTION
## Description

On the server, aside for check for user ownership of an address, we should also check that they have verified their ownership. Otherwise it may be possible to start the linking process for an address, without completing it, and take over an address that was discarded by a previous user.

## How Has This Been Tested?

Tested that each function still works with a normal linked address, and tested that they fail when `verified` is set to false via the DB editor.

## Screenshots (if appropriate):

## Clubhouse tickets/Github issues (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] My change should be included in the release notes.
- [ ] I have updated the documentation accordingly.
- [ ] I have linted the code locally prior to submission.
