### PR TITLE
Fix to allow for community switcher to load without errors

### DIFF
--- a/client/scripts/views/components/community_switcher.ts
+++ b/client/scripts/views/components/community_switcher.ts
@@ -113,7 +113,7 @@ const CommunitySwitcher: m.Component<{}> = {
         communityRoles.map((role) => {
           const address = app.login.addresses.find((a) => a.id === role.address_id);
           const community = app.config.communities.getAll().find((c) => c.id === role.offchain_community_id);
-          return m(CommunitySwitcherCommunity, { community, address });
+          if (community) return m(CommunitySwitcherCommunity, { community, address });
         }),
       ]),
     ]);


### PR DESCRIPTION
In `zak.cap`, fixes an issue where community-switcher  would not load. [First noticed here](https://github.com/hicommonwealth/commonwealth-oss/pull/58#issuecomment-623918114).

Error is caused by an `undefined` community value being passed to the `CommunitySwitcherCommunity`.