### PR TITLE
Subscription Button in Thread Carat on Discussion Page

### DIFF
--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -6,14 +6,15 @@ import { default as moment } from 'moment-twitter';
 
 import app from 'state';
 import { pluralize, slugify, link, externalLink, extractDomain } from 'helpers';
-import { Icon, Icons, Tag, PopoverMenu } from 'construct-ui';
+import { Icon, Icons, Tag, } from 'construct-ui';
 
 import User from 'views/components/widgets/user';
 import { OffchainThread, OffchainThreadKind, OffchainTag } from 'models';
 import MarkdownFormattedText from 'views/components/markdown_formatted_text';
 import QuillFormattedText from 'views/components/quill_formatted_text';
-import TagEditor from 'views/components/tag_editor';
-import { isRoleOfCommunity } from 'helpers/roles';
+
+import ThreadCaratMenu from './thread_carat_menu';
+
 
 interface IAttrs {
   proposal: OffchainThread;
@@ -42,11 +43,6 @@ const DiscussionRow: m.Component<IAttrs> = {
         return 0;
       }
     };
-
-    const canEditTags = app.vm.activeAccount
-      && (isRoleOfCommunity(app.vm.activeAccount, app.login.addresses, app.login.roles, 'admin', app.activeId())
-          || isRoleOfCommunity(app.vm.activeAccount, app.login.addresses, app.login.roles, 'moderator', app.activeId())
-          || proposal.author === app.vm.activeAccount.address);
 
     return m('.DiscussionRow', { key: proposal.identifier }, [
       m('.discussion-row', [
@@ -80,22 +76,7 @@ const DiscussionRow: m.Component<IAttrs> = {
                 `/${app.activeId()}/proposal/${proposal.slug}/${proposal.identifier}-${slugify(proposal.title)}`,
                 [ app.comments.nComments(proposal), m(Icon, { name: Icons.MESSAGE_SQUARE }) ],
               ),
-            canEditTags
-              && m(PopoverMenu, {
-                transitionDuration: 0,
-                closeOnOutsideClick: true,
-                menuAttrs: { size: 'sm', },
-                content: m(TagEditor, {
-                  thread: proposal,
-                  popoverMenu: true,
-                  onChangeHandler: (tags: OffchainTag[]) => { proposal.tags = tags; m.redraw(); },
-                }),
-                trigger: m(Icon, {
-                  name: Icons.CHEVRON_DOWN,
-                  class: 'discussion-edit-tags',
-                  style: 'margin-right: 6px;'
-                }),
-              }),
+              m(ThreadCaratMenu, { proposal }),
           ]),
           propType === OffchainThreadKind.Link
             && proposal.url

--- a/client/scripts/views/pages/discussions/thread_carat_menu.ts
+++ b/client/scripts/views/pages/discussions/thread_carat_menu.ts
@@ -4,35 +4,31 @@ import app from 'state';
 import { isRoleOfCommunity } from 'helpers/roles';
 import { NotificationCategories } from 'types';
 import { OffchainThread, OffchainTag } from 'models';
-import TagEditor from '../../components/tag_editor';
+import TagEditor from 'views/components/tag_editor';
 import { MenuItem, PopoverMenu, Icon, Icons } from 'construct-ui';
 
-
-
-
-export const ThreadSubscriptionButton: m.Component<{proposal: OffchainThread,}> = {
+export const ThreadSubscriptionButton: m.Component<{ proposal: OffchainThread }> = {
   view: (vnode) => {
     const { proposal } = vnode.attrs;
-    const subscriptions = app.login.notifications;
-    const communitySubscription = subscriptions.subscriptions
-      .find((v) => v.category === NotificationCategories.NewComment && v.objectId === proposal.uniqueIdentifier );
+    const notificationSubscription = app.login.notifications.subscriptions
+      .find((v) => v.category === NotificationCategories.NewComment && v.objectId === proposal.uniqueIdentifier);
 
     return m(MenuItem, {
-        onclick: (e) => {
-          e.preventDefault();
-          if (communitySubscription) {
-            subscriptions.deleteSubscription(communitySubscription).then(() => {
-              m.redraw();
-            });
-          } else {
-            subscriptions.subscribe(NotificationCategories.NewComment, proposal.uniqueIdentifier).then(() => {
-              m.redraw();
-            });
-          }
-        },
-        label: communitySubscription ? 'Turn off notifications' : 'Turn on notifications',
-        iconLeft: communitySubscription ? Icons.VOLUME_X : Icons.VOLUME_2,
-      });
+      onclick: (e) => {
+        e.preventDefault();
+        if (notificationSubscription) {
+          app.login.notifications.deleteSubscription(notificationSubscription).then(() => {
+            m.redraw();
+          });
+        } else {
+          app.login.notifications.subscribe(NotificationCategories.NewComment, proposal.uniqueIdentifier).then(() => {
+            m.redraw();
+          });
+        }
+      },
+      label: notificationSubscription ? 'Turn off notifications' : 'Turn on notifications',
+      iconLeft: notificationSubscription ? Icons.VOLUME_X : Icons.VOLUME_2,
+    });
   },
 };
 
@@ -51,15 +47,15 @@ const ThreadCaratMenu: m.Component<IThreadCaratMenuAttrs> = {
     return m(PopoverMenu, {
       transitionDuration: 0,
       closeOnOutsideClick: true,
-      menuAttrs: { size: 'default', },
+      menuAttrs: { size: 'sm' },
       content: [
         canEditTags
           && m(TagEditor, {
-          thread: proposal,
-          popoverMenu: true,
-          onChangeHandler: (tags: OffchainTag[]) => { proposal.tags = tags; m.redraw(); },}),
+            thread: proposal,
+            popoverMenu: true,
+            onChangeHandler: (tags: OffchainTag[]) => { proposal.tags = tags; m.redraw(); } }),
         m(ThreadSubscriptionButton, { proposal }),
-        ],
+      ],
       trigger: m(Icon, {
         name: Icons.CHEVRON_DOWN,
         class: 'discussion-edit-tags',

--- a/client/scripts/views/pages/discussions/thread_carat_menu.ts
+++ b/client/scripts/views/pages/discussions/thread_carat_menu.ts
@@ -1,0 +1,72 @@
+import { default as m } from 'mithril';
+import app from 'state';
+
+import { isRoleOfCommunity } from 'helpers/roles';
+import { NotificationCategories } from 'types';
+import { OffchainThread, OffchainTag } from 'models';
+import TagEditor from '../../components/tag_editor';
+import { MenuItem, PopoverMenu, Icon, Icons } from 'construct-ui';
+
+
+
+
+const ThreadSubscriptionButton: m.Component<{proposal: OffchainThread,}> = {
+  view: (vnode) => {
+    const { proposal } = vnode.attrs;
+    const subscriptions = app.login.notifications;
+    const communitySubscription = subscriptions.subscriptions
+      .find((v) => v.category === NotificationCategories.NewComment && v.objectId === proposal.uniqueIdentifier );
+
+    return m(MenuItem, {
+        onclick: (e) => {
+          e.preventDefault();
+          if (communitySubscription) {
+            subscriptions.deleteSubscription(communitySubscription).then(() => {
+              m.redraw();
+            });
+          } else {
+            subscriptions.subscribe(NotificationCategories.NewComment, proposal.uniqueIdentifier).then(() => {
+              m.redraw();
+            });
+          }
+        },
+        label: communitySubscription ? 'Turn off notifications' : 'Turn on notifications',
+        iconLeft: communitySubscription ? Icons.VOLUME_X : Icons.VOLUME_2,
+      });
+  },
+};
+
+interface IThreadCaratMenuAttrs {
+  proposal: OffchainThread;
+}
+
+const ThreadCaratMenu: m.Component<IThreadCaratMenuAttrs> = {
+  view: (vnode) => {
+    const { proposal } = vnode.attrs;
+    const canEditTags = app.vm.activeAccount
+      && (isRoleOfCommunity(app.vm.activeAccount, app.login.addresses, app.login.roles, 'admin', app.activeId())
+          || isRoleOfCommunity(app.vm.activeAccount, app.login.addresses, app.login.roles, 'moderator', app.activeId())
+          || proposal.author === app.vm.activeAccount.address);
+
+    return m(PopoverMenu, {
+      transitionDuration: 0,
+      closeOnOutsideClick: true,
+      menuAttrs: { size: 'default', },
+      content: [
+        canEditTags
+          && m(TagEditor, {
+          thread: proposal,
+          popoverMenu: true,
+          onChangeHandler: (tags: OffchainTag[]) => { proposal.tags = tags; m.redraw(); },}),
+        m(ThreadSubscriptionButton, { proposal }),
+        ],
+      trigger: m(Icon, {
+        name: Icons.CHEVRON_DOWN,
+        class: 'discussion-edit-tags',
+        style: 'margin-right: 6px;'
+      }),
+    });
+  },
+};
+
+export default ThreadCaratMenu;

--- a/client/scripts/views/pages/discussions/thread_carat_menu.ts
+++ b/client/scripts/views/pages/discussions/thread_carat_menu.ts
@@ -10,7 +10,7 @@ import { MenuItem, PopoverMenu, Icon, Icons } from 'construct-ui';
 
 
 
-const ThreadSubscriptionButton: m.Component<{proposal: OffchainThread,}> = {
+export const ThreadSubscriptionButton: m.Component<{proposal: OffchainThread,}> = {
   view: (vnode) => {
     const { proposal } = vnode.attrs;
     const subscriptions = app.login.notifications;

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -62,6 +62,7 @@ import {
   ProposalBodyEditMenuItem, ProposalBodyDeleteMenuItem, ProposalBodyReplyMenuItem
 } from './body';
 import CreateComment from './create_comment';
+import { ThreadSubscriptionButton } from '../discussions/thread_carat_menu';
 
 interface IProposalHeaderAttrs {
   commentCount: number;
@@ -108,7 +109,19 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
                 ))
             && m(ProposalHeaderSpacer),
           m(ProposalHeaderViewCount, { viewCount }),
+          m(ProposalHeaderSpacer),
           m(ProposalHeaderDelete, { proposal }),
+          m(PopoverMenu, {
+            transitionDuration: 0,
+            closeOnOutsideClick: true,
+            menuAttrs: { size: 'default', },
+            content: m(ThreadSubscriptionButton, { proposal: proposal as OffchainThread }),
+            trigger: m(Icon, {
+              name: Icons.BELL,
+              class: 'discussion-edit-tags',
+              style: 'margin-right: 6px;'
+            }),
+          })
         ]),
         m('.proposal-title', [
           m(ProposalHeaderTitle, { proposal }),

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -10,6 +10,7 @@ import { PopoverMenu, Icon, Icons } from 'construct-ui';
 import Near from 'controllers/chain/near/main';
 import { WalletAccount } from 'nearlib';
 
+import { NotificationCategories } from 'types';
 import app, { LoginState } from 'state';
 import { idToProposal, ProposalType } from 'identifiers';
 import { pluralize, slugify, symbols, link, externalLink, isSameAccount } from 'helpers';
@@ -95,6 +96,9 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
         : app.community.accounts.get(proposal.author, proposal.authorChain))
       : proposal.author;
 
+    const notificationSubscription = app.login.notifications.subscriptions
+      .find((v) => v.category === NotificationCategories.NewComment && v.objectId === proposal.uniqueIdentifier);
+
     return m('.ProposalHeader', {
       class: `proposal-${proposal.slug}`
     }, [
@@ -111,16 +115,15 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
           m(ProposalHeaderViewCount, { viewCount }),
           m(ProposalHeaderSpacer),
           m(ProposalHeaderDelete, { proposal }),
-          m(PopoverMenu, {
+          app.isLoggedIn() && m(PopoverMenu, {
             transitionDuration: 0,
             closeOnOutsideClick: true,
-            menuAttrs: { size: 'default', },
+            closeOnContentClick: true,
+            menuAttrs: { size: 'default' },
             content: m(ThreadSubscriptionButton, { proposal: proposal as OffchainThread }),
-            trigger: m(Icon, {
-              name: Icons.BELL,
-              class: 'discussion-edit-tags',
-              style: 'margin-right: 6px;'
-            }),
+            trigger: m('.ProposalHeaderCaretMenu', [
+              m('a', notificationSubscription ? 'Notifications on' : 'Notifications off'),
+            ]),
           })
         ]),
         m('.proposal-title', [

--- a/client/styles/pages/view_proposal/header.scss
+++ b/client/styles/pages/view_proposal/header.scss
@@ -25,6 +25,7 @@
 
 
     // proposal-tags
+    .ProposalHeaderCaretMenu,
     .ProposalHeaderTags {
         display: inline-block;
         font-size: 14px;
@@ -33,6 +34,7 @@
             top: -1px;
         }
         a {
+            cursor: pointer;
             color: #888;
             text-decoration: none;
             margin-right: 10px;


### PR DESCRIPTION

## Description
- Refactor the Carat Popover Menu for each Discussion Row (or Thread).
- Add a button to subscribe to comments on Thread from carat. Button shows if you are subscribing or unsubscribing from new-comments on thread.
- Add a carat Popover menu to view_proposal page. I made the icon-trigger a Bell instead of carat because there is already a carat on the post for Edit/Reply/Delete. 

### ~TODO:~
- [x] Add Subscription Button to Carat Menu in View_Proposal Page.

## Motivation and Context
Allow users to quickly subscribe to a conversation from the discussions page, rather than needing to open it up. 

## How Has This Been Tested?
UI Tests (Click button), watched routes successfully executed, see UI change accordingly, and DB reflect update correctly. 

## Clubhouse tickets/Github issues (if appropriate):
- https://github.com/hicommonwealth/commonwealth-oss/issues/37

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] My change should be included in the release notes.
- [ ] I have updated the documentation accordingly.
- [x] I have linted the code locally prior to submission.
