### PR TITLE
Community Switcher Unread Activity Pip

### DIFF
--- a/client/scripts/controllers/server/tags.ts
+++ b/client/scripts/controllers/server/tags.ts
@@ -110,7 +110,6 @@ class TagsController {
         community: communityId,
         jwt: app.login.jwt,
       });
-      console.log(response.result);
       if (response.status !== 'Success') {
         throw new Error(`Unsuccessful refresh status: ${response.status}`);
       }

--- a/client/scripts/views/components/community_switcher.ts
+++ b/client/scripts/views/components/community_switcher.ts
@@ -64,7 +64,6 @@ const CommunitySwitcherCommunity: m.Component<{ community: CommunityInfo, addres
     const { community, address } = vnode.attrs;
     const visitedCommunity = !!app.login.unseenPosts[community.name];
     const updatedThreads = app.login.unseenPosts[community.name]?.activePosts || 0;
-    console.log(app.login.unseenPosts);
 
     const active = app.activeCommunityId() === community.id
       && (!address || (address.chain === app.vm.activeAccount?.chain.id

--- a/client/scripts/views/components/community_switcher.ts
+++ b/client/scripts/views/components/community_switcher.ts
@@ -22,6 +22,8 @@ const avatarSize = 16;
 const CommunitySwitcherChain: m.Component<{ chain: string, nodeList: NodeInfo[], address: AddressInfo }> = {
   view: (vnode) => {
     const { chain, nodeList, address } = vnode.attrs;
+    const visitedChain = !!app.login.unseenPosts[chain];
+    const updatedThreads = app.login.unseenPosts[chain]?.activePosts || 0;
 
     const active = app.activeChainId() === chain
       && (!address || (address.chain === app.vm.activeAccount?.chain.id
@@ -46,6 +48,9 @@ const CommunitySwitcherChain: m.Component<{ chain: string, nodeList: NodeInfo[],
         }
       }, [
         m('.icon-inner', [
+          visitedChain
+          && updatedThreads
+          && m('.notification-dot'),
           m(ChainIcon, { chain: nodeList[0].chain }),
           m(User, { user: [address.address, address.chain], avatarOnly: true, avatarSize }),
         ]),
@@ -57,6 +62,9 @@ const CommunitySwitcherChain: m.Component<{ chain: string, nodeList: NodeInfo[],
 const CommunitySwitcherCommunity: m.Component<{ community: CommunityInfo, address: AddressInfo }> = {
   view: (vnode) => {
     const { community, address } = vnode.attrs;
+    const visitedCommunity = !!app.login.unseenPosts[community.name];
+    const updatedThreads = app.login.unseenPosts[community.name]?.activePosts || 0;
+    console.log(app.login.unseenPosts);
 
     const active = app.activeCommunityId() === community.id
       && (!address || (address.chain === app.vm.activeAccount?.chain.id
@@ -81,6 +89,9 @@ const CommunitySwitcherCommunity: m.Component<{ community: CommunityInfo, addres
         },
       }, [
         m('.icon-inner', [
+          visitedCommunity
+          && updatedThreads
+          && m('.notification-dot'),
           m('.name', community.name.slice(0, 2).toLowerCase()),
           m(User, { user: [address.address, address.chain], avatarOnly: true, avatarSize }),
         ]),

--- a/client/scripts/views/components/community_switcher.ts
+++ b/client/scripts/views/components/community_switcher.ts
@@ -22,7 +22,6 @@ const avatarSize = 16;
 const CommunitySwitcherChain: m.Component<{ chain: string, nodeList: NodeInfo[], address: AddressInfo }> = {
   view: (vnode) => {
     const { chain, nodeList, address } = vnode.attrs;
-    const visitedChain = !!app.login.unseenPosts[chain];
     const updatedThreads = app.login.unseenPosts[chain]?.activePosts || 0;
 
     const active = app.activeChainId() === chain
@@ -35,9 +34,12 @@ const CommunitySwitcherChain: m.Component<{ chain: string, nodeList: NodeInfo[],
       content: m('.CommunitySwitcherTooltip', [
         m('.sidebar-tooltip-name', nodeList[0].chain.name),
       ]),
+      hoverOpenDelay: 0,
+      hoverCloseDelay: 0,
+      transitionDuration: 0,
       trigger: m('a.CommunitySwitcherChain', {
         href: '#',
-        class: active ? 'active' : '',
+        class: `${active ? 'active' : ''} ${updatedThreads > 0 ? 'unread' : ''}`,
         onclick: (e) => {
           e.preventDefault();
           if (address) {
@@ -47,10 +49,8 @@ const CommunitySwitcherChain: m.Component<{ chain: string, nodeList: NodeInfo[],
           m.route.set(`/${chain}/`);
         }
       }, [
+        m('.active-bar'),
         m('.icon-inner', [
-          visitedChain
-          && updatedThreads
-          && m('.notification-dot'),
           m(ChainIcon, { chain: nodeList[0].chain }),
           m(User, { user: [address.address, address.chain], avatarOnly: true, avatarSize }),
         ]),
@@ -62,8 +62,7 @@ const CommunitySwitcherChain: m.Component<{ chain: string, nodeList: NodeInfo[],
 const CommunitySwitcherCommunity: m.Component<{ community: CommunityInfo, address: AddressInfo }> = {
   view: (vnode) => {
     const { community, address } = vnode.attrs;
-    const visitedCommunity = !!app.login.unseenPosts[community.name];
-    const updatedThreads = app.login.unseenPosts[community.name]?.activePosts || 0;
+    const updatedThreads = app.login.unseenPosts[community.id]?.activePosts || 0;
 
     const active = app.activeCommunityId() === community.id
       && (!address || (address.chain === app.vm.activeAccount?.chain.id
@@ -75,9 +74,12 @@ const CommunitySwitcherCommunity: m.Component<{ community: CommunityInfo, addres
       content: m('.CommunitySwitcherTooltip', [
         m('.sidebar-tooltip-name', community.name),
       ]),
+      hoverOpenDelay: 0,
+      hoverCloseDelay: 0,
+      transitionDuration: 0,
       trigger: m('a.CommunitySwitcherCommunity', {
         href: '#',
-        class: active ? 'active' : '',
+        class: `${active ? 'active' : ''} ${updatedThreads > 0 ? 'unread' : ''}`,
         onclick: (e) => {
           e.preventDefault();
           if (address) {
@@ -85,12 +87,10 @@ const CommunitySwitcherCommunity: m.Component<{ community: CommunityInfo, addres
             localStorage.setItem('initChain', address.chain);
           }
           m.route.set(`/${community.id}/`);
-        },
+        }
       }, [
+        m('.active-bar'),
         m('.icon-inner', [
-          visitedCommunity
-          && updatedThreads
-          && m('.notification-dot'),
           m('.name', community.name.slice(0, 2).toLowerCase()),
           m(User, { user: [address.address, address.chain], avatarOnly: true, avatarSize }),
         ]),

--- a/client/scripts/views/components/sidebar/notification_row.ts
+++ b/client/scripts/views/components/sidebar/notification_row.ts
@@ -10,12 +10,12 @@ import { NotificationCategories } from 'types';
 import { ProposalType } from 'identifiers';
 import { Notification } from 'models';
 import { IPostNotificationData, ICommunityNotificationData } from 'shared/types';
-import labelEdgewareEvent from '../../../../../shared/events/edgeware/filters/labeler';
 
 import QuillFormattedText, { sliceQuill } from 'views/components/quill_formatted_text';
 import MarkdownFormattedText from 'views/components/markdown_formatted_text';
 import jumpHighlightComment from 'views/pages/view_proposal/jump_to_comment';
 import User from 'views/components/widgets/user';
+import labelEdgewareEvent from '../../../../../shared/events/edgeware/filters/labeler';
 import { getProposalUrl } from '../../../../../shared/utils';
 
 interface IHeaderNotificationRow {

--- a/client/styles/components/community_switcher.scss
+++ b/client/styles/components/community_switcher.scss
@@ -58,8 +58,8 @@ $switcher-item-extra-spacing: 6px;
                 left: 32px;
                 top: -2px;
                 background-color: red;
-                width: 9px;
-                height: 9px;
+                width: 8px;
+                height: 8px;
                 border-radius: 50%;
             }
             .ChainIcon img {

--- a/client/styles/components/community_switcher.scss
+++ b/client/styles/components/community_switcher.scss
@@ -50,18 +50,29 @@ $switcher-item-extra-spacing: 6px;
         color: #222;
         font-weight: 500;
         justify-content: center;
+        .notification-dot {
+            position: absolute;
+            top: $switcher-item-spacing + 2px;
+            left: $switcher-item-spacing + 2px;
+            background-color: $badge-red;
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            z-index: 1;
+        }
+        .active-bar {
+            position: absolute;
+            left: 0;
+            top: $switcher-item-spacing;
+            bottom: $switcher-item-spacing;
+            width: 3px;
+            border-radius: 0 3px 3px 0;
+        }
+        &.active .active-bar {
+            background: #eee;
+        }
         .icon-inner {
             position: relative;
-            opacity: 0.4;
-            .notification-dot {
-                position: relative;
-                left: 32px;
-                top: -2px;
-                background-color: red;
-                width: 8px;
-                height: 8px;
-                border-radius: 50%;
-            }
             .ChainIcon img {
                 width: $switcher-item-size;
                 height: $switcher-item-size;
@@ -72,16 +83,17 @@ $switcher-item-extra-spacing: 6px;
                 bottom: -5px;
             }
         }
-        &.active .icon-inner,
-        &:hover .icon-inner {
-            opacity: 1;
+        &.unread .icon-inner {
+            border: 1px solid #eee;
+            width: $switcher-item-size + 2px;
+            height: $switcher-item-size + 2px;
         }
     }
     a.CommunitySwitcherCommunity {
         .icon-inner {
             text-align: center;
             color: #eee;
-            background: #36393f;
+            background: #555;
             height: $switcher-item-size;
             width: $switcher-item-size;
             border-radius: 8px;
@@ -90,10 +102,10 @@ $switcher-item-extra-spacing: 6px;
                 top: 8px;
             }
         }
-        &:hover, &.active {
-            .icon-inner {
-                background: darken(#36393f, 7%);
-            }
+        &.unread .icon-inner {
+            border: 1px solid #eee;
+            width: $switcher-item-size + 2px;
+            height: $switcher-item-size + 2px;
         }
     }
 }

--- a/client/styles/components/community_switcher.scss
+++ b/client/styles/components/community_switcher.scss
@@ -53,6 +53,15 @@ $switcher-item-extra-spacing: 6px;
         .icon-inner {
             position: relative;
             opacity: 0.4;
+            .notification-dot {
+                position: relative;
+                left: 32px;
+                top: -2px;
+                background-color: red;
+                width: 9px;
+                height: 9px;
+                border-radius: 50%;
+            }
             .ChainIcon img {
                 width: $switcher-item-size;
                 height: $switcher-item-size;

--- a/client/styles/shared.scss
+++ b/client/styles/shared.scss
@@ -5,7 +5,7 @@ $offwhite-extralight: #fcfbfa;
 $offwhite-light: #f9f8f6;
 $offwhite-dark: #282625;
 $badge-red: #de243b;    // radish red for badges
-$badge-lightred: #fa3e3e; // salmon red for weak sauce badges
+$badge-lightred: #fa3e3e; // salmon red for weak badges
 $error-red: #d32e26;    // fleshy red for error messages
 $success-green: green;
 


### PR DESCRIPTION
See [Issue 95](https://github.com/hicommonwealth/commonwealth-oss/issues/95).

## Description
Fairly straightforward feature in motivation & implementation: Users are notified with a red dot in the community switcher when there is unread activity on a joined chain or community, similar to Discord or Slack. (There is not a count of unread activity yet, just a binary yes/no red dot.) This rendering is based on `app.login.unseenPosts`, specifically the unseenActivity prop which counts all updated threads.

## How Has This Been Tested?
Because Construct UI has some issues with chain-community rendering/joining/switching, I have only verified this feature works with offchain communities (though the logic is nearly identical, and should ostensibly work for chain communities as well).

I've tested in Firefox and Chrome, with unread and read posts to check the conditional rendering. And I've tested multiple browser/window sizes, to make sure the positioning & styling held up. 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22281010/81095535-26e4e480-8ed3-11ea-95f2-72578ff9fd62.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)