### PR TITLE
Creates proposals on comment creation if they don't exist.

### DIFF
--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -6,6 +6,7 @@ import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUs
 import lookupAddressIsOwnedByUser from '../util/lookupAddressIsOwnedByUser';
 import { getProposalUrl } from '../../shared/utils';
 import { factory, formatFilename } from '../util/logging';
+import { ProposalType } from 'client/scripts/identifiers';
 const log = factory.getLogger(formatFilename(__filename));
 
 const createComment = async (models, req: UserRequest, res: Response, next: NextFunction) => {
@@ -113,10 +114,30 @@ const createComment = async (models, req: UserRequest, res: Response, next: Next
   // Comments always need identified parents.
   let proposal;
   const [prefix, id] = finalComment.root_id.split('_');
+  console.log(prefix);
   if (prefix === 'discussion') {
     proposal = await models.OffchainThread.findOne({
       where: { id }
     });
+  } else if (prefix.includes('signaling')) {
+    proposal = await models.Proposal.findOne({
+      where: { identifier: id, type: prefix }
+    });
+
+    // TODO: We can remove this once we identify why signal proposals aren't created
+    if (!proposal) {
+      await models.Proposal.create({
+        chain: chain.id,
+        identifier: id,
+        type: prefix,
+        data: {},
+        completed: false,
+      });
+
+      proposal = await models.Proposal.findOne({
+        where: { identifier: id, type: prefix }
+      });
+    }
   } else if (prefix.includes('proposal') || prefix.includes('referendum')) {
     proposal = await models.Proposal.findOne({
       where: { identifier: id, type: prefix }
@@ -124,7 +145,7 @@ const createComment = async (models, req: UserRequest, res: Response, next: Next
   } else {
     log.error(`No matching proposal of thread for root_id ${comment.root_id}`);
   }
-
+  console.log(proposal);
   if (!proposal || proposal.read_only) {
     await finalComment.destroy();
     return next(new Error('Cannot comment when thread is read_only'));

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -114,7 +114,7 @@ const createComment = async (models, req: UserRequest, res: Response, next: Next
   // Comments always need identified parents.
   let proposal;
   const [prefix, id] = finalComment.root_id.split('_');
-  console.log(prefix);
+
   if (prefix === 'discussion') {
     proposal = await models.OffchainThread.findOne({
       where: { id }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Signaling proposals aren't being archived atm it seems and so comment functionality is disabled since no proposal exists. This ensures that if no proposal exists for a comment that we create it (specifically for signaling proposals).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's a bug.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Running locally against Edgeware mainnet and commenting on signaling proposals.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have linted the code locally prior to submission.
