### PR TITLE
Community Switcher Account Change Bug

### DIFF
--- a/client/scripts/views/components/community_switcher.ts
+++ b/client/scripts/views/components/community_switcher.ts
@@ -16,6 +16,7 @@ import { notifySuccess } from 'controllers/app/notifications';
 import ChainIcon from 'views/components/chain_icon';
 import FeedbackModal from 'views/modals/feedback_modal';
 import CommunityMenu from 'views/components/community_menu';
+import { setActiveAccount } from 'controllers/app/login';
 
 const avatarSize = 16;
 
@@ -85,6 +86,10 @@ const CommunitySwitcherCommunity: m.Component<{ community: CommunityInfo, addres
           if (address) {
             localStorage.setItem('initAddress', address.address);
             localStorage.setItem('initChain', address.chain);
+            if (app.vm.activeAccount.address !== address.address) {
+              const account = app.login.activeAddresses.find((addr) => addr.address === address.address);
+              setActiveAccount(account);
+            }
           }
           m.route.set(`/${community.id}/`);
         }

--- a/client/scripts/views/components/community_switcher.ts
+++ b/client/scripts/views/components/community_switcher.ts
@@ -46,6 +46,10 @@ const CommunitySwitcherChain: m.Component<{ chain: string, nodeList: NodeInfo[],
           if (address) {
             localStorage.setItem('initAddress', address.address);
             localStorage.setItem('initChain', address.chain);
+            if (app.vm.activeAccount.address !== address.address) {
+              const account = app.login.activeAddresses.find((addr) => addr.address === address.address);
+              setActiveAccount(account);
+            }
           }
           m.route.set(`/${chain}/`);
         }


### PR DESCRIPTION
## Description
Before: If you had two roles in the same community/chain, and you tried to switch accounts using the `CommunitySwitcher` in the sidebar, the active account would stay the same.
Now: The active account switches according to the Role associated with the community switch button in the sidebar. 

## Motivation and Context
Users should have a seamless experience switching between accounts, regardless of community, on Commonwealth.

## How Has This Been Tested?
- I connected multiple addresses to the Edgeware Chain Community (member roles) as well as to the Internal Offchain Community. 
- I then toggled between them in the sidebar, making sure the activeAddress was changing accordingly. 

## Clubhouse tickets/Github issues (if appropriate):
- https://github.com/hicommonwealth/commonwealth-oss/issues/40

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] My change should be included in the release notes.
- [ ] I have updated the documentation accordingly.
- [ ] I have linted the code locally prior to submission.
