### PR TITLE
Fix "New Post" Button

### DIFF
--- a/client/scripts/views/components/new_proposal_button.ts
+++ b/client/scripts/views/components/new_proposal_button.ts
@@ -22,7 +22,7 @@ const NewProposalButton: m.Component<{ fluid: boolean }> = {
 
     // just a button for communities, or chains without governance
     if (app.community) {
-      return m(Button, {
+      const CommunityButton = m(Button, {
         class: 'NewProposalButton',
         label: 'New post',
         iconLeft: Icons.PLUS,
@@ -31,11 +31,17 @@ const NewProposalButton: m.Component<{ fluid: boolean }> = {
         disabled: !activeAccount,
         onclick: () => app.modals.create({ modal: NewThreadModal }),
       });
+      return activeAccount
+        ? CommunityButton
+        : m(Tooltip, {
+          content: 'Link an address to post',
+          trigger: CommunityButton
+        });
     }
 
-    // a button with popover menu for chains
-    return m(ButtonGroup, [
+    const ProposalButtonGroup = m(ButtonGroup, [
       m(Button, {
+        disabled: !activeAccount,
         intent: 'primary',
         label: 'New post',
         fluid,
@@ -45,17 +51,10 @@ const NewProposalButton: m.Component<{ fluid: boolean }> = {
         class: 'NewProposalButton',
         transitionDuration: 0,
         hoverCloseDelay: 0,
-        trigger: activeAccount ? m(Button, {
+        trigger: m(Button, {
+          disabled: !activeAccount,
           iconLeft: Icons.CHEVRON_DOWN,
           intent: 'primary',
-        }) : m(Tooltip, {
-          content: 'Link an address to post',
-          trigger: m(Button, {
-            iconLeft: Icons.CHEVRON_DOWN,
-            intent: 'primary',
-            class: 'cui-disabled',
-            style: 'cursor: pointer !important',
-          }),
         }),
         position: 'bottom-end',
         closeOnContentClick: true,
@@ -105,6 +104,14 @@ const NewProposalButton: m.Component<{ fluid: boolean }> = {
         ],
       }),
     ]);
+
+    // a button with popover menu for chains
+    return activeAccount
+      ? ProposalButtonGroup
+      : m(Tooltip, {
+        content: 'Link an address to post',
+        trigger: ProposalButtonGroup
+      });
   }
 };
 


### PR DESCRIPTION
See [Issue 184](https://github.com/hicommonwealth/commonwealth-oss/issues/184)

## Description
When the user is logged in and on a chain community, but lacks an active address, the whole "New Post"-derivative ButtonGroup (PopoverMenu) is now disabled and tooltipped.
When the user is logged in and on an offchain community, but lacks an active address, the "New Post" button is disabled & tooltipped.

## Motivation and Context
Previously, users without accounts could still trigger the New Thread modal, and were not being properly instructed as to what missing information they needed to provide.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22281010/81326263-925fbb00-9067-11ea-9365-fcdb061a1b78.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)