### PR TITLE
Proposal & Council Pages: Loading Spinner

### DIFF
--- a/client/scripts/views/pages/council.ts
+++ b/client/scripts/views/pages/council.ts
@@ -181,11 +181,11 @@ const CouncilPage: m.Component<{}> = {
     });
   },
   view: (vnode) => {
-    if (!app.chain) return m(PageLoading);
+    if (!app.chain) return m(PageLoading, { message: 'Chain is loading...' });
 
     const initialized = app.chain && (app.chain as Substrate).phragmenElections.initialized;
 
-    if (!initialized) return m(PageLoading);
+    if (!initialized) return m(PageLoading, { message: 'Chain is loading...' });
 
     const councillors: SubstrateAccount[] = app.chain
       && ((app.chain as Substrate).phragmenElections.members || []).map((a) => app.chain.accounts.get(a));

--- a/client/scripts/views/pages/loading.ts
+++ b/client/scripts/views/pages/loading.ts
@@ -3,10 +3,15 @@ import 'pages/loading.scss';
 import m from 'mithril';
 import { Spinner } from 'construct-ui';
 
-const LoadingPage: m.Component<{}> = {
+const LoadingPage: m.Component<{ message?: string }> = {
   view: (vnode) => {
     return m('.LoadingPage', [
-      m(Spinner, { fill: true, size: 'xl', style: 'visibility: visible; opacity: 1;' }),
+      m(Spinner, {
+        fill: true,
+        message: vnode.attrs.message,
+        size: 'xl',
+        style: 'visibility: visible; opacity: 1;'
+      }),
     ]);
   }
 };

--- a/client/scripts/views/pages/proposals.ts
+++ b/client/scripts/views/pages/proposals.ts
@@ -9,6 +9,7 @@ import { formatDuration, blockperiodToDuration } from 'helpers';
 import { ProposalType } from 'identifiers';
 import { ChainClass, ChainBase } from 'models';
 import Edgeware from 'controllers/chain/edgeware/main';
+import PageLoading from 'views/pages/loading';
 
 import ListingPage from 'views/pages/_listing_page';
 import ConvictionsTable from 'views/components/proposals/convictions_table';
@@ -67,11 +68,12 @@ const ProposalsPage: m.Component<{}> = {
 
     const maxConvictionWeight = Math.max.apply(this, convictions().map((c) => convictionToWeight(c)));
     const maxConvictionLocktime = Math.max.apply(this, convictions().map((c) => convictionToLocktime(c)));
+    if (!app.chain || !app.chain.loaded) return m(PageLoading, { message: 'Chain is loading...' });
     return m(ListingPage, {
       class: 'ProposalsPage',
       title: 'Governance Proposals',
       subtitle: 'Vote on network changes',
-      content: (!app.chain || !app.chain.loaded) ? m('.forum-container', m(ProposalsLoadingRow)) : [
+      content: [
         !visibleReferenda
           && !visibleCouncilProposals
           && !visibleDemocracyProposals

--- a/client/scripts/views/pages/proposals.ts
+++ b/client/scripts/views/pages/proposals.ts
@@ -27,6 +27,7 @@ const ProposalsPage: m.Component<{}> = {
     mixpanel.track('PageVisit', { 'Page Name': 'ProposalsPage' });
   },
   view: (vnode) => {
+    if (!app.chain || !app.chain.loaded) return m(PageLoading, { message: 'Chain is loading...' });
     const onSubstrate = app.chain && app.chain.base === ChainBase.Substrate;
     const onMoloch = app.chain && app.chain.class === ChainClass.Moloch;
 
@@ -68,7 +69,7 @@ const ProposalsPage: m.Component<{}> = {
 
     const maxConvictionWeight = Math.max.apply(this, convictions().map((c) => convictionToWeight(c)));
     const maxConvictionLocktime = Math.max.apply(this, convictions().map((c) => convictionToLocktime(c)));
-    if (!app.chain || !app.chain.loaded) return m(PageLoading, { message: 'Chain is loading...' });
+
     return m(ListingPage, {
       class: 'ProposalsPage',
       title: 'Governance Proposals',


### PR DESCRIPTION
## Description
This branches adds a loading spinner to the proposal and council pages for on- and off-chain communities. The loading spinner is passed an optional attribute `message` which notifies users as to the reason for the delayed load (here "Chain is loading...").

## Motivation and Context
See [Issue 185](https://github.com/hicommonwealth/commonwealth-oss/issues/185).

## How Has This Been Tested?
Loaded up the relevant pages in a couple different environments, but since Construct handles the implementation of Spinner, and this merely reuses + adds an attr, not much to test here.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22281010/81335456-a4485a80-9075-11ea-8a23-3ae2ac6f9150.png)