### PR TITLE
Comment Refresh Bug Fix

### DIFF
--- a/client/scripts/views/pages/view_proposal/body.ts
+++ b/client/scripts/views/pages/view_proposal/body.ts
@@ -321,7 +321,6 @@ export const ProposalBodySaveEdit: m.Component<{
             app.comments.edit(item, itemText).then((c) => {
               parentState.editing = false;
               getSetGlobalEditingStatus(GlobalStatus.Set, false);
-              console.dir('saved');
               callback();
               m.redraw();
             });

--- a/client/scripts/views/pages/view_proposal/body.ts
+++ b/client/scripts/views/pages/view_proposal/body.ts
@@ -322,7 +322,6 @@ export const ProposalBodySaveEdit: m.Component<{
               parentState.editing = false;
               getSetGlobalEditingStatus(GlobalStatus.Set, false);
               callback();
-              m.redraw();
             });
           }
         }

--- a/client/scripts/views/pages/view_proposal/body.ts
+++ b/client/scripts/views/pages/view_proposal/body.ts
@@ -294,9 +294,10 @@ export const ProposalBodySaveEdit: m.Component<{
   item: OffchainThread | OffchainComment<any>,
   getSetGlobalEditingStatus,
   parentState,
+  callback?: Function; // required for OffchainComments
 }> = {
   view: (vnode) => {
-    const { item, getSetGlobalEditingStatus, parentState } = vnode.attrs;
+    const { item, getSetGlobalEditingStatus, parentState, callback } = vnode.attrs;
     if (!item) return;
     const isThread = item instanceof OffchainThread;
 
@@ -320,6 +321,8 @@ export const ProposalBodySaveEdit: m.Component<{
             app.comments.edit(item, itemText).then((c) => {
               parentState.editing = false;
               getSetGlobalEditingStatus(GlobalStatus.Set, false);
+              console.dir('saved');
+              callback();
               m.redraw();
             });
           }

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -167,7 +167,7 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
             m(ProposalHeaderSpacer),
             m(ProposalBodyCancelEdit, { getSetGlobalEditingStatus, parentState: vnode.state }),
             m(ProposalHeaderSpacer),
-            m(ProposalBodySaveEdit, { item: proposal, getSetGlobalEditingStatus, parentState: vnode.state, }),
+            m(ProposalBodySaveEdit, { item: proposal, getSetGlobalEditingStatus, parentState: vnode.state }),
           ],
         ] : [
           m(ProposalHeaderOnchainId, { proposal }),
@@ -627,7 +627,7 @@ const ViewProposalPage: m.Component<{ identifier: string, type: string }, { edit
         commentCount,
         viewCount,
         getSetGlobalEditingStatus,
-        getSetGlobalReplyStatus,
+        getSetGlobalReplyStatus
       }),
       m(ProposalComments, {
         proposal,

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -167,7 +167,7 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
             m(ProposalHeaderSpacer),
             m(ProposalBodyCancelEdit, { getSetGlobalEditingStatus, parentState: vnode.state }),
             m(ProposalHeaderSpacer),
-            m(ProposalBodySaveEdit, { item: proposal, getSetGlobalEditingStatus, parentState: vnode.state }),
+            m(ProposalBodySaveEdit, { item: proposal, getSetGlobalEditingStatus, parentState: vnode.state, }),
           ],
         ] : [
           m(ProposalHeaderOnchainId, { proposal }),
@@ -294,7 +294,7 @@ const ProposalComment: m.Component<IProposalCommentAttrs, IProposalCommentState>
           m(ProposalBodySpacer),
           m(ProposalBodyCancelEdit, { getSetGlobalEditingStatus, parentState: vnode.state }),
           m(ProposalBodySpacer),
-          m(ProposalBodySaveEdit, { item: comment, getSetGlobalEditingStatus, parentState: vnode.state, }),
+          m(ProposalBodySaveEdit, { item: comment, getSetGlobalEditingStatus, parentState: vnode.state, callback }),
         ],
       ]),
       m('.comment-body-content', [
@@ -376,6 +376,7 @@ const ProposalComments: m.Component<IProposalCommentsAttrs, IProposalCommentsSta
             getSetGlobalReplyStatus,
             parent: comment,
             proposal,
+            callback: createdCommentCallback,
           }),
           !!child.childComments.length
             && m('.child-comments-wrap', recursivelyGatherChildComments(child, replyParent2))
@@ -392,6 +393,7 @@ const ProposalComments: m.Component<IProposalCommentsAttrs, IProposalCommentsSta
             getSetGlobalReplyStatus,
             parent: proposal,
             proposal,
+            callback: createdCommentCallback,
           }),
           // if comment has children, they are fetched & rendered
           !!comment.childComments.length
@@ -625,7 +627,7 @@ const ViewProposalPage: m.Component<{ identifier: string, type: string }, { edit
         commentCount,
         viewCount,
         getSetGlobalEditingStatus,
-        getSetGlobalReplyStatus
+        getSetGlobalReplyStatus,
       }),
       m(ProposalComments, {
         proposal,


### PR DESCRIPTION

## Description
Comments on Threads would not redraw on edit-save, but Comments on Comments would redraw just fine. This was a UI bug I noticed on the a previous PR that was, at the time, not revealing itself to be squashed quickly. 
The fix: Pass the comment section parent refresh callback into the 'save' component of the comments. This brute force redraws the comments from the parent down, rather than the individual comment itself (which has a redraw). Still not sure why comments on comments would refresh but not comments on the proposal/thread itself. 

## Motivation and Context
UI needs to reflect the updates the user makes. 

## How Has This Been Tested?
1. Create/access a thread 
2. Comment on thread, redraws new comment
3. Comment on a comment, redraws that new secondary comment. 
4. Edit the comment-on-comment, redraws updated comment correctly.
5. Edit initial comment, or any comment on the proposal/thread, redraws updated comment correctly (this was the bug initially; would fail to redraw)

## Clubhouse tickets/Github issues (if appropriate):
- https://github.com/hicommonwealth/commonwealth-oss/issues/109

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] My change should be included in the release notes.
- [ ] I have updated the documentation accordingly.
- [ ] I have linted the code locally prior to submission.
