### PR TITLE
Proper Tag Scoping

### DIFF
--- a/client/scripts/controllers/chain/community/main.ts
+++ b/client/scripts/controllers/chain/community/main.ts
@@ -19,7 +19,7 @@ class Community extends ICommunityAdapter<Coin, OffchainAccount> {
     await this.app.threads.refreshAll(null, this.id, true);
     await this.app.comments.refreshAll(null, this.id, true);
     await this.app.reactions.refreshAll(null, this.id, true);
-    await this.app.tags.refreshAll(this.meta.id);
+    await this.app.tags.refreshAll(null, this.id, true);
     this._serverLoaded = true;
     this._loaded = true;
   }

--- a/client/scripts/controllers/server/tags.ts
+++ b/client/scripts/controllers/server/tags.ts
@@ -109,7 +109,6 @@ class TagsController {
       const response = await $.get(`${app.serverUrl()}/bulkTags`, {
         chain: chainId || app.activeChainId(),
         community: communityId || app.activeCommunityId(),
-        jwt: app.login.jwt,
       });
       if (response.status !== 'Success') {
         throw new Error(`Unsuccessful refresh status: ${response.status}`);

--- a/client/scripts/controllers/server/tags.ts
+++ b/client/scripts/controllers/server/tags.ts
@@ -72,6 +72,7 @@ class TagsController {
         'name': name,
         'jwt': app.login.jwt,
       });
+      debugger
       const result = modelFromServer(response.result);
       if (this._store.getById(result.id)) {
         this._store.remove(this._store.getById(result.id));
@@ -103,14 +104,13 @@ class TagsController {
     }
   }
 
-  public async refreshAll(communityId?, chainId?, reset = false) {
+  public async refreshAll(chainId, communityId, reset = false) {
     try {
       const response = await $.get(`${app.serverUrl()}/bulkTags`, {
-        chain: chainId,
-        community: communityId,
+        chain: chainId || app.activeChainId(),
+        community: communityId || app.activeCommunityId(),
         jwt: app.login.jwt,
       });
-      console.log(response.result);
       if (response.status !== 'Success') {
         throw new Error(`Unsuccessful refresh status: ${response.status}`);
       }
@@ -119,7 +119,6 @@ class TagsController {
       }
       const tags = (app.chain) ? response.result.filter((tag) => !tag.communityId) : response.result;
       tags.forEach((t) => this._store.add(modelFromServer(t)));
-      console.log(this._store);
       this._initialized = true;
     } catch (err) {
       console.log('Failed to load offchain tags');

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -22,6 +22,7 @@ const modelFromServer = (thread) => {
     thread.kind,
     thread.version_history,
     thread.community,
+    thread.chain,
     thread.private,
     thread.read_only,
     decodeURIComponent(thread.body),

--- a/client/scripts/models/IChainAdapter.ts
+++ b/client/scripts/models/IChainAdapter.ts
@@ -23,6 +23,7 @@ abstract class IChainAdapter<C extends Coin, A extends Account<C>> {
     await this.app.threads.refreshAll(this.id, null, true);
     await this.app.comments.refreshAll(this.id, null, true);
     await this.app.reactions.refreshAll(this.id, null, true);
+    await this.app.tags.refreshAll(this.id, null, true);
     this._serverLoaded = true;
     if (onServerLoaded) await onServerLoaded();
     await initChainModuleFn();

--- a/client/scripts/models/OffchainThread.ts
+++ b/client/scripts/models/OffchainThread.ts
@@ -24,7 +24,8 @@ class OffchainThread implements IUniqueId {
   public readonly slug = 'discussion';
   public readonly url: string;
   public readonly versionHistory: string[];
-  public readonly community: string | number;
+  public readonly community: string;
+  public readonly chain: string;
 
   public get uniqueIdentifier() {
     return `${this.slug}_${this.identifier}`;
@@ -39,7 +40,8 @@ class OffchainThread implements IUniqueId {
     tags: OffchainTag[],
     kind: OffchainThreadKind,
     versionHistory: string[],
-    community: number | string,
+    community: string,
+    chain: string,
     privacy: boolean,
     readOnly: boolean,
     body?: string,
@@ -61,6 +63,7 @@ class OffchainThread implements IUniqueId {
     this.url = url;
     this.versionHistory = versionHistory;
     this.community = community;
+    this.chain = chain;
     this.privacy = privacy;
     this.readOnly = readOnly;
   }

--- a/client/scripts/views/components/sidebar/tag_selector.ts
+++ b/client/scripts/views/components/sidebar/tag_selector.ts
@@ -178,12 +178,7 @@ export const getTagListing = (params: IGetTagListingParams) => {
     });
   });
 
-  const a = app;
-  const cT = app.tags.getByCommunity(app.activeId());
-  debugger
-
   const threadlessTags = app.tags.getByCommunity(app.activeId()).forEach((tag) => {
-    debugger
     if (featuredTagIds.includes(`${tag.id}`)) {
       if (!featuredTags[`${tag.name}`]) {
         featuredTags[tag.name] = {

--- a/client/scripts/views/components/sidebar/tag_selector.ts
+++ b/client/scripts/views/components/sidebar/tag_selector.ts
@@ -178,7 +178,7 @@ export const getTagListing = (params: IGetTagListingParams) => {
     });
   });
 
-  const threadlessTags = app.tags.store.getAll().map((tag) => {
+  const threadlessTags = app.tags.getByCommunity(app.activeId()).forEach((tag) => {
     if (featuredTagIds.includes(`${tag.id}`)) {
       if (!featuredTags[`${tag.name}`]) {
         featuredTags[tag.name] = {

--- a/client/scripts/views/components/sidebar/tag_selector.ts
+++ b/client/scripts/views/components/sidebar/tag_selector.ts
@@ -178,7 +178,12 @@ export const getTagListing = (params: IGetTagListingParams) => {
     });
   });
 
+  const a = app;
+  const cT = app.tags.getByCommunity(app.activeId());
+  debugger
+
   const threadlessTags = app.tags.getByCommunity(app.activeId()).forEach((tag) => {
+    debugger
     if (featuredTagIds.includes(`${tag.id}`)) {
       if (!featuredTags[`${tag.name}`]) {
         featuredTags[tag.name] = {
@@ -239,6 +244,7 @@ const NewTagButton: m.Component = {
       iconLeft: Icons.PLUS,
       onclick: async (e) => {
         e.preventDefault();
+        if (!isCommunityAdmin()) return;
         const tag = await inputModalWithText('New Tag:')();
         if (!tag) return;
         app.tags.add(tag).then(() => { m.redraw(); });
@@ -290,7 +296,7 @@ const TagSelector: m.Component<{
       }, featuredTagListing),
       showFullListing && m('h4', featuredTagListing.length > 0 ? 'Other tags' : 'Tags'),
       showFullListing && !!otherTagListing.length && m(List, { class: 'other-tag-list' }, otherTagListing),
-      showFullListing && m(NewTagButton),
+      showFullListing && isCommunityAdmin() && m(NewTagButton),
       !showFullListing
         && (app.community || app.chain)
         && m(List, [

--- a/server/router.ts
+++ b/server/router.ts
@@ -134,7 +134,7 @@ function setupRouter(app, models, fetcher, viewCountCache: ViewCountCache) {
   router.post('/updateTags', passport.authenticate('jwt', { session: false }), updateTags.bind(this, models));
   router.post('/editTag', passport.authenticate('jwt', { session: false }), editTag.bind(this, models));
   router.post('/deleteTag', passport.authenticate('jwt', { session: false }), deleteTag.bind(this, models));
-  router.get('/bulkTags', passport.authenticate('jwt', { session: false }), bulkTags.bind(this, models));
+  router.get('/bulkTags', bulkTags.bind(this, models));
 
   // offchain reactions
   router.post('/createReaction', passport.authenticate('jwt', { session: false }), createReaction.bind(this, models));


### PR DESCRIPTION
## Description
See issue #161 for context.

Previously, we were getting bleed-through between communities, where tags from e.g. Edgeware were popping up in Meta & vice-versa. It was unclear exactly what was causing this; the initial ticket's specs held that tags were not properly chain- or community-scoped, but both in the store and the database, there were clear filters & designations for tags' respective chains/communities. A second contention was that we were lacking a community/chain-scoped _route_, to fetch & populate the store with community-specific data. Neither of these contentions were the case (`api/bulkTags` is in fact _only_ community- or chain-scoped, perhaps misleadingly due to its name).

In fact, the Tags Controller refreshAll method which wrapped our main bulkTags call was being _improperly_ called on initialization (`main.ts` in Communities). Rather than passing in a community, a community was being passed as a chain (due to improperly written optional function params). The route would error, and there was no "second source of truth" besides the tag associations on a forum's threads (thus, our newly introduced feature, admin-only "threadless tags," would go unlisted if community-distinguished). This restores proper functionality to the (already community-scoped) bulkTags route.

Additionally, there was no front-end check (isCommunityAdmin) for the creation of new tags, and there was no chain property attached to the thread store. Threadless tags did not grab only from a community, but from the full tag store. These smaller issues further contributed to the breakdown of functionality, but have been here addressed.

The possibility of narrowing the store, such that the current community's tags are the only tags in the store (thus purging the necessity of having tags.communityStore/getByCommunity functionality) was brought up in conversations around this ticket as a possible solution, but it turned out not, in fact, to be central to the problem or solution. I've kept this functionality up for the time being, though this decision is painlessly reversible.

## How Has This Been Tested?
Logged in as admin and not as admin.
Flipped between community and chain tag pages, reproducing the "bleedthrough" effect, and verifying post-fix that it was no longer occurring.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22281010/81723730-4b037100-9451-11ea-8f5b-5a2a8ebf54a9.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have linted the code locally prior to submission.
