### PR TITLE
Construct User Menu

### DIFF
--- a/client/scripts/views/components/header.ts
+++ b/client/scripts/views/components/header.ts
@@ -18,6 +18,7 @@ import LinkNewAddressModal from 'views/modals/link_new_address_modal';
 import NewProposalButton from 'views/components/new_proposal_button';
 import NotificationRow from 'views/components/sidebar/notification_row';
 import ConfirmInviteModal from 'views/modals/confirm_invite_modal';
+import EditProfileModal from 'views/modals/edit_profile_modal';
 
 const Header: m.Component<{}> = {
   view: (vnode) => {
@@ -109,6 +110,15 @@ const Header: m.Component<{}> = {
             onclick: () => m.route.set(`/${app.activeChainId()}/admin`),
             iconLeft: Icons.USER,
             label: 'Admin'
+          }),
+          app.vm.activeAccount
+          && m(MenuItem, {
+            onclick: () => app.modals.create({
+              modal: EditProfileModal,
+              data: app.vm.activeAccount
+            }),
+            iconLeft: Icons.EDIT,
+            label: 'Edit Profile'
           }),
           m(MenuItem, {
             onclick: () => app.modals.create({ modal: FeedbackModal }),

--- a/client/scripts/views/components/header.ts
+++ b/client/scripts/views/components/header.ts
@@ -19,6 +19,7 @@ import NewProposalButton from 'views/components/new_proposal_button';
 import NotificationRow from 'views/components/sidebar/notification_row';
 import ConfirmInviteModal from 'views/modals/confirm_invite_modal';
 import EditProfileModal from 'views/modals/edit_profile_modal';
+import EditIdentityModal from '../modals/edit_identity_modal';
 
 const Header: m.Component<{}> = {
   view: (vnode) => {
@@ -119,6 +120,14 @@ const Header: m.Component<{}> = {
             }),
             iconLeft: Icons.EDIT,
             label: 'Edit Profile'
+          }),
+          m(MenuItem, {
+            onclick: async () => app.modals.create({
+              modal: EditIdentityModal,
+              data: { account: app.vm.activeAccount },
+            }),
+            iconLeft: Icons.LINK,
+            label: 'Set on-chain ID'
           }),
           m(MenuItem, {
             onclick: () => app.modals.create({ modal: FeedbackModal }),


### PR DESCRIPTION
See Issue #183 for context.

## Description
User menu now links to EditIdentityModal and EditProfileModal, as requested.

## How Has This Been Tested?
Works properly for my profile set-up, passing in the active account as data for the modals, but would be great if someone with a better sense of how possible address/profile/account combos manifest ensured that everything was synced up—can imagine there being an issue going from specificity level of an account to specificity level of a user or address profile.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22281010/81735060-7d699a00-9462-11ea-88d4-f86f2c3fed4f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
