### PR TITLE
CommunitySwitcher Icons

### DIFF
--- a/client/scripts/views/components/community_menu.ts
+++ b/client/scripts/views/components/community_menu.ts
@@ -126,14 +126,6 @@ const CommunityMenu: m.Component<{}> = {
         return m(CommunityMenuCommunity, { community, address });
       }),
       app.login.roles.length > 0 && m('hr'),
-      m(CommunityMenuLink, {
-        onclick: (e) => {
-          e.preventDefault();
-          m.route.set('/')
-        },
-        icon: Icons.HOME,
-        label: 'Home'
-      }),
     ]);
   }
 };

--- a/client/scripts/views/components/community_switcher.ts
+++ b/client/scripts/views/components/community_switcher.ts
@@ -105,26 +105,31 @@ const CommunitySwitcher: m.Component<{}, { communityMenuVisible: boolean }> = {
 
     const chainRoles = app.login.roles.filter((role) => !role.offchain_community_id);
     const communityRoles = app.login.roles.filter((role) => role.offchain_community_id);
+    const HomeButton = m('.home-button-wrap', [
+      m(Button, {
+        onclick: (e) => {
+          if (m.route.get() !== '/') m.route.set('/');
+        },
+        class: '.sidebar-logo',
+        iconLeft: Icons.HOME,
+        size: 'xl'
+      })
+    ]);
 
     return m('.CommunitySwitcher', [
-      m(Popover, {
-        portalAttrs: { class: 'community-menu-portal' },
-        class: 'community-menu-popover',
-        hasBackdrop: true,
-        content: m(CommunityMenu),
-        hasArrow: false,
-        closeOnEscapeKey: true,
-        closeOnContentClick: true,
-        closeOnOutsideClick: true,
-        trigger: m(Button, {
-          onclick: (e) => {
-            if (m.route.get() !== '/') m.route.set('/');
-          },
-          class: '.sidebar-logo',
-          iconLeft: Icons.HOME,
-          size: 'xl'
-        }),
-      }),
+      app.isLoggedIn()
+        ? m(Popover, {
+          portalAttrs: { class: 'community-menu-portal' },
+          class: 'community-menu-popover',
+          hasBackdrop: true,
+          content: m(CommunityMenu),
+          hasArrow: false,
+          closeOnEscapeKey: true,
+          closeOnContentClick: true,
+          closeOnOutsideClick: true,
+          trigger: HomeButton
+        })
+        : HomeButton,
       m('.sidebar-content', [
         chainRoles.map((role) => {
           const address = app.login.addresses.find((a) => a.id === role.address_id);

--- a/client/scripts/views/components/community_switcher.ts
+++ b/client/scripts/views/components/community_switcher.ts
@@ -1,20 +1,13 @@
 import 'components/community_switcher.scss';
 
 import m from 'mithril';
-import $ from 'jquery';
-import mixpanel from 'mixpanel-browser';
-import { Icon, Icons, Popover, PopoverMenu, MenuItem, Button, Tooltip } from 'construct-ui';
+import { Icons, Popover, Button, Tooltip } from 'construct-ui';
 
 import app from 'state';
-import { initAppState } from 'app';
-import { link } from 'helpers';
 
 import { AddressInfo, CommunityInfo, NodeInfo } from 'models';
-import { isMember } from 'views/components/membership_button';
 import User from 'views/components/widgets/user';
-import { notifySuccess } from 'controllers/app/notifications';
 import ChainIcon from 'views/components/chain_icon';
-import FeedbackModal from 'views/modals/feedback_modal';
 import CommunityMenu from 'views/components/community_menu';
 
 const avatarSize = 16;
@@ -102,6 +95,7 @@ const CommunitySwitcherCommunity: m.Component<{ community: CommunityInfo, addres
 const CommunitySwitcher: m.Component<{}, { communityMenuVisible: boolean }> = {
   view: (vnode) => {
     if (!app.isLoggedIn()) return;
+    if (!vnode.state.communityMenuVisible) vnode.state.communityMenuVisible = false;
 
     const chains = {};
     app.config.nodes.getAll().forEach((n) => {
@@ -119,17 +113,16 @@ const CommunitySwitcher: m.Component<{}, { communityMenuVisible: boolean }> = {
       m(Popover, {
         portalAttrs: { class: 'community-menu-portal' },
         class: 'community-menu-popover',
-        isOpen: vnode.state.communityMenuVisible,
         hasBackdrop: true,
         content: m(CommunityMenu),
-        onClose: () => {
-          vnode.state.communityMenuVisible = false;
-        },
         hasArrow: false,
         closeOnEscapeKey: true,
         closeOnContentClick: true,
+        closeOnOutsideClick: true,
         trigger: m(Button, {
-          onclick: (e) => m.route.set('/'),
+          onclick: (e) => {
+            if (m.route.get() !== '/') m.route.set('/');
+          },
           class: '.sidebar-logo',
           iconLeft: Icons.HOME,
           size: 'xl'
@@ -145,6 +138,21 @@ const CommunitySwitcher: m.Component<{}, { communityMenuVisible: boolean }> = {
           const community = app.config.communities.getAll().find((c) => c.id === role.offchain_community_id);
           return m(CommunitySwitcherCommunity, { community, address });
         }),
+        m(Popover, {
+          portalAttrs: { class: 'community-menu-portal' },
+          class: 'community-menu-popover',
+          hasBackdrop: true,
+          content: m(CommunityMenu),
+          hasArrow: false,
+          closeOnEscapeKey: true,
+          closeOnContentClick: true,
+          closeOnOutsideClick: true,
+          trigger: m('a.CommunitySwitcherCommunity', [
+            m('.icon-inner', [
+              m('.name', '...')
+            ]),
+          ])
+        })
       ]),
     ]);
   }

--- a/client/scripts/views/components/community_switcher.ts
+++ b/client/scripts/views/components/community_switcher.ts
@@ -128,7 +128,12 @@ const CommunitySwitcher: m.Component<{}, { communityMenuVisible: boolean }> = {
         hasArrow: false,
         closeOnEscapeKey: true,
         closeOnContentClick: true,
-        trigger: m('.sidebar-logo', '🤔'),
+        trigger: m(Button, {
+          onclick: (e) => m.route.set('/'),
+          class: '.sidebar-logo',
+          iconLeft: Icons.HOME,
+          size: 'xl'
+        }),
       }),
       m('.sidebar-content', [
         chainRoles.map((role) => {

--- a/client/scripts/views/components/community_switcher.ts
+++ b/client/scripts/views/components/community_switcher.ts
@@ -94,9 +94,6 @@ const CommunitySwitcherCommunity: m.Component<{ community: CommunityInfo, addres
 
 const CommunitySwitcher: m.Component<{}, { communityMenuVisible: boolean }> = {
   view: (vnode) => {
-    if (!app.isLoggedIn()) return;
-    if (!vnode.state.communityMenuVisible) vnode.state.communityMenuVisible = false;
-
     const chains = {};
     app.config.nodes.getAll().forEach((n) => {
       if (chains[n.chain.id]) {
@@ -138,7 +135,7 @@ const CommunitySwitcher: m.Component<{}, { communityMenuVisible: boolean }> = {
           const community = app.config.communities.getAll().find((c) => c.id === role.offchain_community_id);
           return m(CommunitySwitcherCommunity, { community, address });
         }),
-        m(Popover, {
+        app.isLoggedIn() && m(Popover, {
           portalAttrs: { class: 'community-menu-portal' },
           class: 'community-menu-popover',
           hasBackdrop: true,

--- a/client/styles/components/community_switcher.scss
+++ b/client/styles/components/community_switcher.scss
@@ -90,6 +90,7 @@ $switcher-item-extra-spacing: 6px;
         }
     }
     a.CommunitySwitcherCommunity {
+        cursor: pointer;
         .icon-inner {
             text-align: center;
             color: #eee;

--- a/client/styles/components/community_switcher.scss
+++ b/client/styles/components/community_switcher.scss
@@ -14,6 +14,12 @@ $switcher-item-extra-spacing: 6px;
     z-index: 10;
     user-select: none;
     align-items: center;
+    .home-button-wrap {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin: 5px;
+    }
     .sidebar-logo {
         position: absolute;
         top: 0;
@@ -36,7 +42,7 @@ $switcher-item-extra-spacing: 6px;
         border-top: 1px solid #444;
         padding: $switcher-item-extra-spacing 0;
         width: 100%;
-        overflow-y: scroll;
+        overflow-y: auto;
         overflow-x: hidden;
     }
     a.CommunitySwitcherChain,

--- a/client/styles/components/header.scss
+++ b/client/styles/components/header.scss
@@ -5,7 +5,7 @@
     top: 0;
     left: $sidebar-width;
     &.logged-out {
-        left: $sidebar-width - $switcher-width;
+        left: $sidebar-width;
     }
     right: 0;
     height: $header-height;

--- a/client/styles/components/sidebar/index.scss
+++ b/client/styles/components/sidebar/index.scss
@@ -11,9 +11,6 @@ $active-color: #e9e9f5;
     width: $sidebar-width - $switcher-width;
     z-index: 9;
     border-right: 1px solid #e8e8e8;
-    &.logged-out {
-        left: 0;
-    }
     .SidebarMenu {
         height: 100%;
     }

--- a/client/styles/layout.scss
+++ b/client/styles/layout.scss
@@ -241,16 +241,16 @@ body.modal-open {
     padding: 15px 40px;
     padding-top: $header-height + 15px;
     padding-left: $sidebar-width + 40px;
-    &.logged-out {
-        padding-left: $sidebar-width;
-    }
+    // &.logged-out {
+    //     padding-left: $sidebar-width;
+    // }
     &.navigation-hidden {
         padding-left: $switcher-width + 40px;
         padding-top: 15px;
     }
-    &.navigation-hidden.logged-out {
-        padding-left: 40px;
-    }
+    // &.navigation-hidden.logged-out {
+    //     padding-left: 40px;
+    // }
 }
 
 @media (max-width: 680px) {


### PR DESCRIPTION
## Description
- Replaces the thinking face emoji with a xl-sized home icon which navigates upon click to the root page of Commonwealth ('/')
- Adds a 'more' button at the bottom of the community switcher, after all chains and communities, styled styled and componentized similar to the chain and community tiles, which on click opens the community menu.
- Removes the home menu option from the community menu
- Renders the switcher even without a logged-in user, while hiding the 'More' button

## Motivation and Context
Continuous improvements to Construct UI.

## How Has This Been Tested?
Logged-in/logged out. Not much to it—tested the Popover in Firefox and Chrome, but Construct tends to handle that kind of inter-browser operability pretty well.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22281010/81983098-d111ea00-9600-11ea-945d-cecfebf27bab.png)

## Clubhouse tickets/Github issues (if appropriate):
Resolves #180.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)