### PR TITLE
Update Substrate node URLs 

### DIFF
--- a/server/migrations/20200522152856-update-substrate-urls.js
+++ b/server/migrations/20200522152856-update-substrate-urls.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.bulkUpdate('ChainNodes', {
+        url: 'ws://mainnet1.edgewa.re:9944'
+      }, {
+        url: 'wss://mainnet1.edgewa.re'
+      });
+      await queryInterface.bulkUpdate('ChainNodes', {
+        url: 'ws://mainnet2.edgewa.re:9944'
+      }, {
+        url: 'wss://mainnet2.edgewa.re'
+      });
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.bulkUpdate('ChainNodes', {
+        url: 'wss://mainnet1.edgewa.re'
+      }, {
+        url: 'ws://mainnet1.edgewa.re:9944'
+      });
+      await queryInterface.bulkUpdate('ChainNodes', {
+        url: 'wss://mainnet2.edgewa.re'
+      }, {
+        url: 'ws://mainnet2.edgewa.re:9944'
+      });
+    });
+  }
+};


### PR DESCRIPTION
Closes #224.

## Description
Updates ChainNode URLs from non-working wss:// to working ws://...9944. On merge with master, we will switch back to secure websockets.

## How has this been tested?
The migration was run; the desired rows were updated & checked in Postgres; the websocket URLs appear to run without errors.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no